### PR TITLE
Homepage rework: single-screen atelier → Solve et Coagula transmutation hero

### DIFF
--- a/.claude/rebrand/research-hero-backgrounds.md
+++ b/.claude/rebrand/research-hero-backgrounds.md
@@ -1,0 +1,298 @@
+# Hero Background Rework — Research Report
+
+**Scope:** Replace the current hero canvas (starfield + nebula + cursor-proximity constellation lines, `assets/js/observatory.js`, 416 lines) with a bespoke, alive, on-brand background for "Henrique A. Lavezzo — Code Alchemist."
+**Date:** 2026-07-19
+**Hard constraints honored throughout:** first-party code only (vanilla Canvas 2D or raw WebGL/GLSL — no three.js/p5/pixi), WCAG 2.2.2 pause control + reduced-motion *substitution*, no-JS static fallback, bounded CPU/GPU work, AA-legible text on dark palette (#211C30→#312A45, gold #e6a553).
+
+---
+
+## 1. The cliché map — why the current hero reads as "template"
+
+The specific tells that make a hero background read as tutorial-grade in 2024–2026:
+
+1. **Particles joined by proximity lines ("constellation").** This is the single most-copied canvas effect on the web. It is the signature output of particles.js (Vincent Garreau, 2015) and its successor tsParticles — described even by fan articles as "one of the most copied solutions across the web" ([cssscript.com](https://www.cssscript.com/canvas-particle-animation/), [particles.js.org](https://particles.js.org/), [speckyboy round-up](https://speckyboy.com/particle-animation-code-snippets/)). The cursor-linking variant is the default demo config. Any viewer who has seen five startup sites has seen this exact effect.
+2. **Slow-drift starfields with no depth story.** Random dots + tiny velocity + wraparound is the first canvas tutorial most people write ([kirupa's 3D starfield tutorial](https://www.kirupa.com/animations/animated_3d_starfield_effect.htm) is literally an intro-to-canvas lesson). Without parallax layers, depth, or narrative it reads as screensaver.
+3. **Generic gradient blobs / aurora smears.** Now shipped as stock components by UI kits ([Aceternity "Modern Hero With Gradients"](https://ui.aceternity.com/blocks/hero-sections/modern-hero-with-gradients)) and sold as image packs ([Grainient](https://grainient.supply/collections/hero-gradients)); Design Shack's 2025 trend survey treats "gradient meshes, aurora, blobs" as a commodity category ([designshack.net](https://designshack.net/articles/trends/background-design-trends/)).
+4. **The AI-slop signature.** The 2025–26 homogenization critique is now explicit: "you can spot AI-generated landing pages immediately by the purple-to-indigo gradient in the hero… the default color Tailwind CSS shipped with, now appearing on what feels like half the internet" ([Wheels Up Collective, "We Don't Want a Beige Internet"](https://www.wheelsupcollective.com/post/we-dont-want-a-beige-internet)). A dark-violet site with a drifting particle field sits dangerously close to this signature *by accident of palette* — the background must be unmistakably authored to escape it.
+5. **Motion without meaning.** The common thread: the effect exists because it was easy, not because it says anything. Awwwards' own editorial on shader effects stresses that what separates featured work is *purposeful implementation* and integration with the site's visual language, not the effect itself ([awwwards.com, "The Rise of Shaders, Filters and Effects"](https://www.awwwards.com/the-rise-of-shaders-filters-and-effects-in-web-projects.html)).
+
+**Verdict on the current hero:** it stacks tells #1 + #2 + (by palette) #4. Keeping any cursor-proximity line-linking in the rework, in any styling, keeps the cliché.
+
+---
+
+## 2. Technique taxonomy
+
+For each: what it is → feel → build → performance → a11y → real examples.
+
+### 2.1 Fragment-shader gradients / aurora / plasma / domain-warped fBm
+
+- **What:** A fullscreen quad + fragment shader computing color per pixel from layered value/simplex noise. The premium version is **domain warping**: `f(p) = fbm(p + fbm(p + fbm(p)))` — feeding noise back into its own coordinates. Canonical reference: Inigo Quilez ([iquilezles.org/articles/warp](https://iquilezles.org/articles/warp/)), whose exact pattern is:
+  ```glsl
+  vec2 q = vec2(fbm(p + vec2(0.0,0.0)), fbm(p + vec2(5.2,1.3)));
+  vec2 r = vec2(fbm(p + 4.0*q + vec2(1.7,9.2)), fbm(p + 4.0*q + vec2(8.3,2.8)));
+  float f = fbm(p + 4.0*r);
+  // q and r are FREE secondary signals — drive hue/glow from them
+  ```
+- **Feel:** Smoke, marble, nebular ink, "living mineral." Reads as authored because the color ramp and warp constants are yours; nobody else's field looks the same.
+- **Build:** Raw WebGL1 is enough — one program, one fullscreen triangle, ~150 lines of boilerplate. Time uniform advanced slowly. Study pieces: [Shadertoy "Domain warped FBM"](https://www.shadertoy.com/view/wttXz8), [Domain Warping Study](https://www.shadertoy.com/view/W3KyR3), aurora reference [Shadertoy "Auroras" by nimitz](https://www.shadertoy.com/view/XtGGRt).
+- **Performance:** 3 nested fBm × 4–5 octaves = ~60 noise evaluations/pixel. Fine on desktop GPUs; on mobile render at half resolution and upscale (imperceptible for smoke), or drop to 3 octaves. Cost is *fixed* per frame — no unbounded work.
+- **A11y:** Motion is pure color/opacity evolution — no translation, no parallax, lowest vestibular-risk category per Smashing Magazine's reduced-motion guidance ([smashingmagazine.com](https://www.smashingmagazine.com/2020/09/design-reduced-motion-sensitivities/)). Freezing the time uniform yields a *premium still* — the substitution problem solves itself.
+- **Examples:** the entire "hero shader" genre on Awwwards ([Hero Shader collection](https://www.awwwards.com/awwwards/collections/webgl-shaders-code/)); shader-studio SOTD winners like [Shader Development Studio](https://www.awwwards.com/sites/shader-development-studio).
+
+### 2.2 Flow fields / curl-noise particles
+
+- **What:** Particles advected through a vector field. **Curl noise** is the key upgrade: take the curl of a noise potential (`v = (∂n/∂y, −∂n/∂x)` in 2D via central differences) — the result is divergence-free, so particles *never clump or vacuum out*; they swirl like incompressible fluid ([emildziewanowski.com/curl-noise](https://emildziewanowski.com/curl-noise/), [Chris Arasin's Canvas-2D curl-dots](https://chrisarasin.com/curl-noise-dots/)).
+- **Feel:** Ink in water, wind, spirits, "turbulent yet organized." Trails (draw with low-alpha fade instead of clearRect) give a silk/smoke ribbon look ([clicktorelease, "Lines on flow fields"](https://www.clicktorelease.com/code/generative-lines-flow-fields/), [Sighack "Perlin Noise Fields"](https://sighack.com/post/getting-creative-with-perlin-noise-fields), [varun.ca/noise](https://varun.ca/noise/)).
+- **Build:** Canvas 2D handles 1,000–3,000 particles with trails at 60fps easily (Arasin's demo is plain Canvas). Raw WebGL GL_POINTS handles 100k+. First-party value-noise implementation is ~40 lines.
+- **Performance:** Linear in particle count; fully bounded. Cap count by `devicePixelRatio`/viewport; halve on `navigator.hardwareConcurrency < 4`.
+- **A11y:** Continuous drift *is* motion — needs the pause control; but flow motion is local and small-scale (not page-panning), so vestibular risk is moderate-low. Reduced-motion substitute: render one long-exposure pass at load (run the field 300 steps into an offscreen canvas, show the static trail painting — genuinely beautiful stills).
+- **Examples:** [charlottedann.com "Magical vector fields"](https://charlottedann.com/article/magical-vector-fields); the UntilLabs hero (below) uses curl noise + fBm for its "molecular" motion layer.
+
+### 2.3 Metaballs / gooey fields
+
+- **What:** Sum of inverse-square falloffs from N moving blobs, thresholded: `Σ rᵢ²/|p−cᵢ|² > T`. In a fragment shader this is a one-liner per ball; on Canvas 2D use marching squares on a coarse grid for vector outlines ([Jamie Wong, "Metaballs and WebGL"](https://jamie-wong.com/2016/07/06/metaballs-and-webgl/), [Codrops "Drawing 2D Metaballs with WebGL2"](https://tympanus.net/codrops/2021/01/19/drawing-2d-metaballs-with-webgl2/), [vishald.com gooey shader](https://vishald.com/blog/gooey-webgl/)).
+- **Feel:** Mercury, lava-lamp, alchemical fluid merging/splitting — literally *solve et coagula* as physics.
+- **Build:** Fragment shader with 6–10 balls = trivial GPU cost. Smooth-min (`smin`) blending gives the liquid-metal look.
+- **Performance:** O(pixels × balls); with ≤12 balls it's near-free.
+- **A11y:** Ball motion is slow local drift; freeze positions for the still. Threshold/edge glow can animate via opacity only under reduced motion.
+- **Examples:** [Codrops droplet metaballs (2025)](https://tympanus.net/codrops/2025/06/09/how-to-create-interactive-droplet-like-metaballs-with-three-js-and-glsl/); Chamoy Creative gooey effect writeup ([medium/@cmiscm](https://medium.com/@cmiscm/gooey-effect-for-chamoy-creative-4ce0b5ff5baf)).
+
+### 2.4 Voronoi / organic cellular
+
+- **What:** Distance-to-nearest-seed partitioning; IQ's border technique gives mathematically crisp cell edges ([iquilezles.org/articles/voronoilines](https://iquilezles.org/articles/voronoilines/), [cellularffx](https://iquilezles.org/articles/cellularffx/), [Book of Shaders ch. 12](https://thebookofshaders.com/12/)).
+- **Feel:** Crystal lattice, cracked glaze, stained glass, cells. Animating seed points slowly makes the lattice breathe.
+- **Build:** Pure fragment shader; 3×3 grid neighborhood search keeps it cheap ([Sangil Lee's cellular-noise survey](https://sangillee.com/2025-04-18-cellular-noises/)).
+- **Performance:** ~9 distance evaluations per pixel — very cheap.
+- **A11y:** Excellent — edge-glow pulsing is pure opacity animation; static lattice is a strong still.
+- **Examples:** [Shadertoy "Voronoi - distances"](https://www.shadertoy.com/view/ldl3W8); crystal aesthetics of [Igloo Inc](https://www.awwwards.com/sites/igloo-inc) (procedural crystal growth, Awwwards Site of the Year 2024).
+
+### 2.5 Dithering / halftone / Bayer / CRT
+
+- **What:** Quantize a smooth field to few colors, using an ordered Bayer threshold matrix so the error becomes a visible retro pattern. Recursive definition fits in 3 lines of GLSL ([Codrops "A Quick Guide to Bayer Dithering"](https://tympanus.net/codrops/2025/07/30/interactive-webgl-backgrounds-a-quick-guide-to-bayer-dithering/)):
+  ```glsl
+  float Bayer2(vec2 a){ a = floor(a); return fract(a.x/2. + a.y*a.y*.75); }
+  #define Bayer4(a)  (Bayer2(.5*(a))*.25 + Bayer2(a))
+  #define Bayer8(a)  (Bayer4(.5*(a))*.25 + Bayer2(a))
+  // color = field > Bayer8(gl_FragCoord.xy) ? ink : paper;
+  ```
+- **Feel:** Deliberate, crafted, "early bitmap era" — Maxime Heckel: the constraint "contrasts pleasantly against the modern web landscape" ([blog.maximeheckel.com](https://blog.maximeheckel.com/posts/the-art-of-dithering-and-retro-shading-web/)). For this site it's also a direct Final-Fantasy-pixel-era signifier.
+- **Build:** Fragment shader; combine with any field (fBm, gradient, image luminance). Blue-noise texture variant for a less mechanical grain.
+- **Performance:** The Codrops implementation renders "in under 0.2 ms even at 4K" and ships in ~3 KB of shader code — among the cheapest fully-interactive backgrounds possible.
+- **A11y:** Superb — the *pattern* carries the aesthetic even when frozen; interaction can be click-triggered ripples (user-initiated motion is outside 2.2.2's auto-start clause).
+- **Examples:** **JetBrains' Junie campaign page** used exactly this ([cited by Codrops](https://tympanus.net/codrops/2025/07/30/interactive-webgl-backgrounds-a-quick-guide-to-bayer-dithering/)); [Codrops real-time dithering shader (June 2025)](https://tympanus.net/codrops/2025/06/04/building-a-real-time-dithering-shader/); already commodified into UI kits ([Cult UI "Hero Dithering"](https://www.cult-ui.com/docs/components/hero-dithering)) — so use it as a *finish* on a bespoke field, not as the whole idea.
+
+### 2.6 ASCII / text-mode rendering
+
+- **What:** Divide the frame into cells, map cell luminance to glyph density; glyphs drawn procedurally ("shaders don't have fonts" — Efecto draws characters on a 5×7 pixel grid with math, no font atlas needed) ([Codrops "Efecto", Jan 2026](https://tympanus.net/codrops/2026/01/04/efecto-building-real-time-ascii-and-dithering-effects-with-webgl-shaders/), [Codrops ASCII shader with OGL, Nov 2024](https://tympanus.net/codrops/2024/11/13/creating-an-ascii-shader-using-ogl/)).
+- **Feel:** Terminal, code-as-matter. On-brand for an engineer, and the glyph set can be **runes** instead of ASCII — same algorithm, different atlas.
+- **Build:** WebGL cell shader, or Canvas 2D `fillText` on a coarse grid (fine at ≤80×45 cells).
+- **Performance:** GPU version trivial; Canvas version bounded by cell count, not pixels.
+- **A11y:** **Must** be `aria-hidden` and pointer-transparent so the fake text never reaches screen readers or selection. Static frame is characterful.
+- **Examples:** [nextjs-ascii-hero demo](https://nextjs-ascii-hero.vercel.app/); Efecto's 8 styles including "matrix" and "braille."
+
+### 2.7 Reaction–diffusion (Gray-Scott)
+
+- **What:** Two virtual chemicals feed/kill each other on a grid; iterate `A' = A + (Dᴬ∇²A − AB² + f(1−A))·Δt`, `B' = B + (Dᴮ∇²B + AB² − (k+f)B)·Δt`. Produces coral, lichen, fingerprint, leopard patterns that *grow* ([pmneila's classic WebGL demo](https://pmneila.github.io/jsexp/grayscott/), [Jérémie Piellard's reaction-diffusion](https://piellardj.github.io/reaction-diffusion-webgl/), [amandaghassaei's shader](https://github.com/amandaghassaei/ReactionDiffusionShader), parameter atlas at [mrob.com/pub/comp/xmorphia](https://www.mrob.com/pub/comp/xmorphia/index.html)).
+- **Feel:** Matter organizing itself — the most literal "transmutation" of any technique here. Patterns are emergent, never twice the same, unmistakably not a template.
+- **Build:** Raw WebGL ping-pong between two framebuffers (needs float or half-float textures — universally supported since ~2014 per the WebGL Gray-Scott implementations above). ~8–20 sim steps/frame at half resolution.
+- **Performance:** Bounded (fixed steps × fixed grid). Key trick: RD **converges** — you can run it toward a stable state and stop, meaning the background can *finish* animating.
+- **A11y:** The best 2.2.2 story in the taxonomy: growth-to-stillness within ~4–5 s per user-triggered event is compliant *by construction* (auto-start clause requires >5 s of parallel motion — [W3C Understanding 2.2.2](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)). Reduced motion: pre-run the sim invisibly and present the converged still.
+
+### 2.8 Generative sacred geometry / L-systems / cymatics
+
+- **What:** Rule-driven construction of geometric figures. Standout for this brand: **Chladni/cymatic patterns** — standing-wave nodal lines `sin(mπx)·sin(nπy) ± sin(nπx)·sin(mπy) ≈ 0`; integer mode numbers (m,n) each produce a distinct rune-like figure ([CymaVis](https://cymavis.com/), [Shadertoy Chladni emulator](https://www.shadertoy.com/view/3tsSDr), [interactive Chladni simulator](https://pettaboy.github.io/cymaticssimulator_chladni)). L-systems and algorithmic-art context: [Dan MacKinlay's generative-art notebook](https://danmackinlay.name/notebook/generative_art.html), [Samila generator paper](https://arxiv.org/pdf/2504.04298).
+- **Feel:** "Hidden order made visible" — the mystical-mathematical register the alchemy brand already occupies; particles settling onto nodal lines look like iron filings obeying an invisible sigil.
+- **Build:** Canvas 2D: N particles random-walk downhill on `|chladni(p)|` (settle onto nodal lines in ~2–3 s); or fragment shader: luminous line where `|chladni(p)| < ε`. Trivial math, no noise library needed.
+- **Performance:** Cheap either way; the particle version is bounded by count.
+- **A11y:** Discrete "re-tune → settle → still" episodes (each <5 s, triggerable by click/scroll) sidestep continuous animation entirely; each rest state is a finished figure.
+
+### 2.9 Ink-/fluid-in-water diffusion
+
+- **What:** Full Navier-Stokes GPU solve (advection/divergence/pressure ping-pong shaders) — the famous [Pavel Dobryakov WebGL-Fluid-Simulation](https://github.com/PavelDoGreat/WebGL-Fluid-Simulation) ([live](https://paveldogreat.github.io/WebGL-Fluid-Simulation)); or cheaper: a dye field advected by curl noise (no pressure solve) — [Tom Larkworthy's "Ink in water"](https://observablehq.com/@tomlarkworthy/ink).
+- **Feel:** Luxurious, tactile; pointer strokes leave living ink.
+- **Build:** Real fluid = ~6 shader passes/frame + double-buffered FBOs; substantial engineering first-party. Curl-advected dye = one advection pass, much simpler, 80 % of the look.
+- **Performance:** Full sim is the heaviest option here (multiple fullscreen passes; battery cost on mobile is real). Half-res sim buffers mandatory.
+- **A11y:** Pointer-driven splats are user-initiated (good), but the dissipating dye keeps moving >5 s after input — still needs pause. Reduced motion: static ink-blot still.
+- **Caveat:** Dobryakov's demo has been embedded on thousands of sites since 2019 — as a *whole-hero* effect it is now its own cliché tier.
+
+### 2.10 Animated gradient mesh (Stripe-style)
+
+- **What:** Vertex-displaced mesh with per-vertex color blending — Stripe's hero, reverse-engineered widely ([bram.us how-to](https://www.bram.us/2021/10/13/how-to-create-the-stripe-website-gradient-effect/), [minigl gist (~10 kB, ~800 lines)](https://gist.github.com/jordienr/64bcf75f8b08641f205bd6a1a0d4ce1d), [kevinhufnagl.com](https://kevinhufnagl.com/how-to-stripe-website-gradient-effect/)). Note Stripe's own perf discipline: a scroll observer disables the effect when off-screen.
+- **Feel:** Corporate-premium… which is exactly the problem. It's Stripe's brand, endlessly cloned.
+- **Verdict:** Study its engineering (tiny first-party GL wrapper, off-screen pause); do not copy its look. Cliché tell #3.
+
+### 2.11 Starfields done WELL (depth, warp, story)
+
+- **What:** What separates a good starfield: (a) fragment-shader stars from hashed coordinates, multiple parallax layers ([john-smith.me parallax starfield](https://www.john-smith.me/parallax-starfield-and-texture-mask-effect-in-webgl.html), [rocket-boots/webgl-starfield](https://github.com/rocket-boots/webgl-starfield)); (b) *narrative* — the stars belong to a place, as in Igloo Inc's frozen-landscape scroll journey ([case study](https://www.awwwards.com/igloo-inc-case-study.html)).
+- **A11y warning:** warp/zoom starfields are large-scale radial motion — exactly the high vestibular-risk category ([web.dev motion guidance](https://web.dev/learn/accessibility/motion), [Smashing](https://www.smashingmagazine.com/2020/09/design-reduced-motion-sensitivities/)). Given the owner's verdict and the constraint list, **retire the starfield** rather than rehabilitate it.
+
+### 2.12 Cursor-reactive distortion / repulsion / displacement
+
+- **What:** A persistent low-res "flowmap" texture accumulates pointer velocity with decay; the main shader samples it to displace UVs / bend the field locally ([Codrops "Mouse Flowmap Deformation"](https://tympanus.net/codrops/2019/09/25/mouse-flowmap-deformation-with-ogl/), [Interactive WebGL Hover Effects](https://tympanus.net/codrops/2020/04/14/interactive-webgl-hover-effects/)).
+- **Feel:** The background is a *substance* you disturb — categorically different from cursor-line-linking because the response is material (warp, wake, ripple), not diagrammatic (lines).
+- **Build:** One extra small FBO (e.g. 128²) + additive splat + decay ≈ 40 lines of GLSL. Canvas-2D equivalent: keep a small grid of displacement vectors, splat + decay in JS.
+- **A11y:** Interaction-triggered motion falls under **2.3.3 Animation from Interactions** (allow disabling non-essential interaction motion — [W3C Understanding 2.3.3](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html)); wire it to the same motion toggle. Decay must be short so nothing keeps moving >5 s after input.
+
+### 2.13 Film grain / chromatic aberration overlays
+
+- **What:** Post-process finish: luminance-adaptive noise grain ([mattdesl/glsl-film-grain](https://github.com/mattdesl/glsl-film-grain), [maximmcnair.com film-grain writeup](https://maximmcnair.com/p/webgl-film-grain), [fxhash "All about that grain"](https://www.fxhash.xyz/article/all-about-that-grain)); RGB-split sampling for aberration at edges.
+- **Feel:** Removes the "vector-clean" digital look; makes flat gradients feel photographed. Grain alone upgrades a static fallback dramatically.
+- **A11y:** Animated grain flicker is motion — keep grain **static** (single hashed frame) under reduced motion; static grain is also the cheapest way to make the no-JS still feel premium.
+- **Warning:** aberration at >2 px on text-adjacent areas harms legibility; apply only below/behind a text scrim.
+
+---
+
+## 3. What award-winning sites actually do
+
+Patterns extracted from Awwwards SOTD/SOTY case studies and Codrops case studies (galleries for further mining: [awwwards WebGL](https://www.awwwards.com/websites/webgl/), [godly.website](https://godly.website/), [land-book.com](https://land-book.com/)):
+
+1. **The background enacts the site's one idea.** Igloo Inc (Awwwards **Site of the Year 2024**): procedurally *grown* ice crystals, frost dissolves, portfolio pieces encased in ice — the company is named Igloo ([case study](https://www.awwwards.com/igloo-inc-case-study.html), [technical writeup](https://www.webgpu.com/showcase/igloo-inc-procedural-crystals/)). UntilLabs: mission is "preserving the possibility of life," so a real photograph becomes 60,000 particles moving under fBm + curl noise — "make the experience feel alive" is the stated design goal, and concept drives execution rather than ornament ([Codrops case study, Dec 2025](https://tympanus.net/codrops/2025/12/10/simulating-life-in-the-browser-creating-a-living-particle-system-for-the-untillabs-website/)).
+2. **One signature material, not many effects.** Award heroes commit to a single "substance" (ice, ink, dust, dither) and push its fidelity. The Awwwards shader editorial's featured work (Adidas Climazone, Converse Counterclimate, CAMPER FW16) uses effects *tied to the campaign subject* — heat distortion for climate gear, etc. ([awwwards.com](https://www.awwwards.com/the-rise-of-shaders-filters-and-effects-in-web-projects.html)).
+3. **Interaction as material response, not UI garnish.** Pointer input disturbs the substance (wake, melt, ripple) rather than spawning decoration. UntilLabs' particles reorganize; Igloo's frost dissolves on transition.
+4. **Engineering discipline is part of the craft.** Data baked into textures instead of JSON (UntilLabs: 20 MB → 604 KB); UI text rendered via SDF atlas swaps to avoid relayout (Igloo); Stripe disabling the shader off-viewport. Performance restraint is *itself* a pattern of the winners.
+5. **Restraint in the text zone.** Featured heroes keep the effect's contrast/motion away from the headline area or scrim it — the effect frames the message, never competes with it.
+
+**Bespoke vs decorative, distilled:** a decorative background could be swapped onto any other site unchanged; a bespoke one would be *nonsense* on any other site. Test every concept in §4 against that sentence.
+
+---
+
+## 4. On-brand ideation — six concepts for "Code Alchemist"
+
+Shared foundations for all six (details in §5/§6): pause/play control in hero corner; `prefers-reduced-motion` → premium static substitute (never a blank); no-JS fallback = pre-rendered still of the same scene; `visibilitychange` + IntersectionObserver stop the rAF loop; deterministic seed so the fallback still matches the live scene.
+
+### Concept A — "Solve et Coagula" (particle transmutation cycle) ★ flagship candidate
+
+- **Concept & feeling:** The motto, literally enacted. A few thousand gold-and-pastel motes endlessly cycle between two states: **solve** — the assembled figure dissolves into curl-noise turbulence; **coagula** — the cloud condenses onto a target figure (alchemical circle, a rune, or the sigil glyphs the site already owns). The background *is* the brand's thesis: matter dissolved and re-formed, chaos ↔ order. Nothing about it could live on another site.
+- **Technique (first-party, Canvas 2D or WebGL points):**
+  - Rasterize the target figure once to an offscreen canvas; `getImageData` → sample N target points where alpha > 0 (this is the UntilLabs "data as geometry" move, done with your own SVG sigils instead of a photo).
+  - Each particle: `pos += mix(curlNoise(pos, t), (target − pos) * k, phase)` where `phase ∈ [0,1]` eases between solve and coagula. 2-D curl noise from value noise via central differences:
+    ```js
+    // v = perpendicular gradient of noise => divergence-free swirl
+    const e = 0.5;
+    const dx = noise(x, y + e) - noise(x, y - e);
+    const dy = noise(x + e, y) - noise(x - e, y);
+    vx =  dx * S;  vy = -dy * S;   // rotate gradient 90°
+    ```
+  - 1,500–2,500 particles with alpha-fade trails is comfortably 60 fps in Canvas 2D ([Arasin's curl-dots is plain Canvas](https://chrisarasin.com/curl-noise-dots/)); WebGL GL_POINTS if you ever want 50k.
+- **Interaction:** Pointer is the **alchemist's hand**: a gentle curl vortex follows it during *solve* (stirring the dissolved matter); during *coagula* particles near the pointer settle faster, as if attention crystallizes them. **Idle** (no input 30 s): hold the coagulated figure, breathing via opacity only. **Click** = trigger one full solve→coagula cycle toward the *next* figure in a small set (fire/water/air/earth/quintessence — the site's existing element glyphs). Scroll fades the canvas out under the fold.
+- **A11y story:** Auto-play mode runs continuously → the pause control covers 2.2.2 ([W3C Understanding 2.2.2](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)). A stronger variant: default to **episodic mode** — page load runs exactly one dissolve→condense (≤4.5 s) then rests; every further cycle is click-triggered; auto-start motion never exceeds 5 s, so 2.2.2's auto-start clause is satisfied by construction and the pause button becomes belt-and-braces. Reduced motion: skip straight to the coagulated figure as a static long-exposure render (pre-run trails offscreen), pointer effects off (2.3.3).
+- **Why it beats the constellation:** the constellation's particles are random and its lines are noise; here every particle has *purpose and destination* — it's the difference between static and story.
+
+### Concept B — "Prima Materia" (domain-warped aurum field, dither-finished) ★ co-flagship
+
+- **Concept & feeling:** The hero is a slab of **prima materia** — dark violet philosophical smoke (the palette's #211C30→#312A45 as nigredo) shot through with slowly-moving veins of gold (#e6a553, the aurum). Finished with a subtle Bayer-dither quantization so the smoke has the *grain of a 16-bit-era sky* — the Final Fantasy signifier, done as texture rather than pastiche.
+- **Technique (raw WebGL fragment shader, ~200 lines total):**
+  ```glsl
+  // IQ domain warp; q & r drive color for free
+  vec2 q = vec2(fbm(p), fbm(p + vec2(5.2,1.3)));
+  vec2 r = vec2(fbm(p + 4.0*q + 0.02*t), fbm(p + 4.0*q + vec2(8.3,2.8)));
+  float f = fbm(p + 4.0*r);
+  vec3 col = mix(NIGREDO, VIOLET, smoothstep(.2,.7,f));
+  col = mix(col, AURUM, smoothstep(.68,.86, f * dot(q,q)));   // rare gold veins
+  col = floor(col * L + Bayer8(gl_FragCoord.xy)) / L;          // dither finish, L≈6 levels
+  ```
+  Time scale tiny (`0.02*t`): the field should evolve like weather, not boil. Sources: [IQ warp](https://iquilezles.org/articles/warp/), [Codrops Bayer guide](https://tympanus.net/codrops/2025/07/30/interactive-webgl-backgrounds-a-quick-guide-to-bayer-dithering/) (their measured cost: <0.2 ms at 4K).
+- **Interaction:** Pointer = **philosopher's stone**: a small influence field (accumulated in a 128² flowmap with decay, per [Codrops flowmap](https://tympanus.net/codrops/2019/09/25/mouse-flowmap-deformation-with-ogl/)) locally raises the gold threshold — matter *transmutes to gold where touched*, then decays back to lead over ~3 s. Click: a slow gold bloom ripple (Bayer-threshold wave, as in the Codrops click-ripple). No displacement of the field itself near text.
+- **A11y story:** Base evolution is pure color-field change (lowest vestibular category), but it's continuous → pause control required and provided; pause freezes `t` (the frozen frame is indistinguishable from an art print). Reduced motion: `t` frozen at the curated seed, pointer transmutation becomes a simple opacity glow or is dropped; dither grain static. No-JS: export the exact seed frame as AVIF/WebP `background-image` — pixel-identical still.
+- **Why it beats the constellation:** it replaces a diagram with a *material*; the FF-era grain and gold-vein story are unclonable by a template, and it is the cheapest living background in this list.
+
+### Concept C — "The Great Work grows" (reaction–diffusion gold lichen)
+
+- **Concept & feeling:** Transmutation as *growth*. From the sigil's seed points, a Gray-Scott reaction-diffusion pattern grows across the dark field like gold lichen/coral — organic, slightly uncanny, never the same twice. It visibly *becomes*, then rests.
+- **Technique:** Raw WebGL ping-pong FBO pair (half-float), Gray-Scott update (§2.7 equations), f/k chosen from the coral/mitosis region of the [Pearson parameter atlas](https://www.mrob.com/pub/comp/xmorphia/index.html); seed B-chemical from the rasterized sigil. 10–15 steps/frame at half resolution for ~4 s until visually converged, then stop stepping. Color: map B concentration through nigredo→violet→gold ramp. Reference implementations: [pmneila](https://pmneila.github.io/jsexp/grayscott/), [piellardj](https://piellardj.github.io/reaction-diffusion-webgl/).
+- **Interaction:** Pointer hover = local feed-rate perturbation → the lichen *reaches toward* the cursor and blooms (then re-converges ≤4 s). Click = drop a reagent seed. Idle = perfect stillness (it's a grown artifact, not a video).
+- **A11y story:** The strongest by construction — motion happens in **finite growth episodes ≤5 s**, each auto-started only once at load; everything else is user-triggered. Pause control still shipped (stops mid-growth). Reduced motion: run the growth *invisibly* at load (or precompute), reveal the converged pattern with a single opacity fade.
+- **Why it beats the constellation:** emergence is the opposite of template — RD output cannot be faked by a config file, and "watch matter organize itself" is the brand's thesis rendered as chemistry.
+
+### Concept D — "Chladni Sigils" (cymatic resonance figures)
+
+- **Concept & feeling:** Invisible resonance organizes dust into rune-geometry. Fine gold particles settle onto the nodal lines of standing waves — every mode number pair (m,n) is a different "sigil," discovered rather than drawn. Deeply alchemical (vibration → form; the *unseen order*), and adjacent to the site's existing sacred-geometry circle.
+- **Technique (Canvas 2D, no noise lib needed):** particles gradient-descend on `|C(p)|` where `C(p) = sin(mπx)sin(nπy) + sin(nπx)sin(mπy)` ([CymaVis](https://cymavis.com/) documents the classical equation; toy references: [Shadertoy Chladni](https://www.shadertoy.com/view/3tsSDr), [pettaboy simulator](https://pettaboy.github.io/cymaticssimulator_chladni)). Settle time ~2–3 s; add per-particle jitter ∝ `|C|` so lines shimmer faintly at rest (opacity-level motion).
+- **Interaction:** Scroll or click **re-tunes** the plate to the next (m,n) — dust migrates to the new figure in one ≤4 s episode. Pointer emits a tiny local vibration that briefly scatters nearby dust (it re-settles). Could tune (m,n) from pointer position quantized to integers — "find the resonances."
+- **A11y story:** Same episodic structure as C — finite settle episodes, rest states are still figures; auto-start = one settle at load (<5 s). Reduced motion: show the settled figure immediately, no scatter response.
+- **Why it beats the constellation:** the geometry is *earned* from physics rather than randomly linked, and mode-switching gives the pointer/scroll a discoverable, game-like delight (very RPG: "you found resonance VII").
+
+### Concept E — "Runic Ashfall" (rune-mode rendering of a living field)
+
+- **Concept & feeling:** The lower atmosphere of the hero is rendered in **text-mode — but the glyph set is the site's runes**, not ASCII. A slow domain-warped field's luminance chooses which rune (or blank) each cell shows and at what gold intensity: code-as-matter, an engineer's terminal possessed by alchemy.
+- **Technique:** Coarse grid (≈72×40 cells). Canvas 2D: precompute each rune sprite once to offscreen canvases, then blit per cell by field luminance (bounded by cell count, cheap); or WebGL cell shader with a self-made rune atlas texture (the [Efecto](https://tympanus.net/codrops/2026/01/04/efecto-building-real-time-ascii-and-dithering-effects-with-webgl-shaders/) / [Codrops OGL ASCII](https://tympanus.net/codrops/2024/11/13/creating-an-ascii-shader-using-ogl/) architecture). Field = 3-octave fBm, very slow t.
+- **Interaction:** Pointer brightens/sharpens glyphs in a small radius (revealing "legible" runes in the noise — a decode moment); click briefly cascades a column, FF-battle-intro style. Idle: near-still, single-cell twinkles (opacity only).
+- **A11y story:** `aria-hidden="true"` + `pointer-events: none` mandatory (§2.6). Continuous cell changes → pause control; reduced motion → static rune field frame (excellent still — it reads as an inscription).
+- **Why it beats the constellation:** it's the only concept that fuses the *engineer* and *alchemist* identities in one image, and text-mode is currently a distinctive award-scene aesthetic ([Efecto](https://tympanus.net/codrops/2026/01/04/efecto-building-real-time-ascii-and-dithering-effects-with-webgl-shaders/)) that templates haven't commodified with runes.
+
+### Concept F — "Quicksilver" (metaball mercury under the circle)
+
+- **Concept & feeling:** A pool of slow liquid metal — 8–10 metaballs in violet-black with gold rim-light — merging and splitting beneath the hero content: mercury, the alchemist's element, forever dividing and rejoining (solve/coagula again, as fluid).
+- **Technique:** Fragment shader field `Σ rᵢ²/|p−cᵢ|²` with smooth-min blending, thresholded with a soft edge + fresnel-ish gold rim (`smoothstep` band at the threshold). Ball centers on slow Lissajous paths. ([Jamie Wong](https://jamie-wong.com/2016/07/06/metaballs-and-webgl/), [Codrops WebGL2 metaballs](https://tympanus.net/codrops/2021/01/19/drawing-2d-metaballs-with-webgl2/).)
+- **Interaction:** Pointer is a repulsor — the mercury *shies away* then re-merges (material response, cf. §2.12); click splits the nearest blob in two (they slowly re-coagulate).
+- **A11y story:** Slow local drift; pause freezes positions (a still of merged mercury is handsome). Reduced motion: static merged pool, gold rim breathing via opacity only or fully static.
+- **Why it beats the constellation:** a single tangible substance with real interior logic vs. scattered dots; the weakest of the six on distinctiveness (gooey blobs have UI-kit presence) — rank it last unless combined with B's dither finish.
+
+---
+
+## 5. Reduced-motion & pause patterns in the wild
+
+**The normative baseline.** SC 2.2.2: auto-starting motion lasting >5 s presented in parallel with other content requires a mechanism to pause, stop, or hide it ([W3C Understanding 2.2.2](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html)). The mechanism must not trap focus (hover-to-pause alone fails). Whether `prefers-reduced-motion` alone can be that "mechanism" is an **open dispute in the WCAG working group itself** ([w3c/wcag#4319](https://github.com/w3c/wcag/issues/4319), [w3c/wcag#3766](https://github.com/w3c/wcag/issues/3766)) — the "platform-level mechanism" argument exists but has no settled consensus. This project's stance (real on-page control regardless) is the defensible conservative reading, and matches practitioner guidance: designers should include visible pause buttons so the control is discoverable ([designsystemproblems.com](https://designsystemproblems.com/accessibility-compliance/animation-pause-controls/), [BOIA](https://www.boia.org/blog/does-wcag-pause-stop-hide-apply-to-simple-animations)).
+
+**Real control patterns:**
+- **Header/global motion toggle:** the Animal Crossing: New Horizons site ships a motion on/off toggle in its header; Netlify's "1 Million Devs" site shipped a custom animation toggle — both cited as model implementations by CSS-Tricks ([css-tricks.com](https://css-tricks.com/accessible-web-animation-the-wcag-on-animation-explained/)).
+- **Per-figure play/stop buttons:** the "Dark Side of the Grid" article gives every animated figure its own play/stop control styled to the design ([via CSS-Tricks](https://css-tricks.com/accessible-web-animation-the-wcag-on-animation-explained/)).
+- **Background-media pause in a design system:** Western Washington University's pattern library bakes a pause button into its banner background-video component ([marcom.wwu.edu](https://marcom.wwu.edu/accessibility/guide/pause-stop-hide-animation)).
+- **Toggle mechanics:** `<button aria-pressed>` toggling a root class + persisting to `localStorage`, *initialized from* `matchMedia('(prefers-reduced-motion: reduce)')` so OS preference is the default and the toggle can override in both directions ([Pope Tech](https://blog.pope.tech/2025/12/08/design-accessible-animation-and-movement/), [web.dev motion](https://web.dev/learn/accessibility/motion), [a11y with Lindsey](https://www.a11ywithlindsey.com/blog/reducing-motion-improve-accessibility/)). Craft CMS's writeup covers defaulting such toggles sensibly ([craftcms.com](https://craftcms.com/blog/designing-for-reduced-motion)).
+- **Substitute, don't delete:** where motion carries meaning, reduced-motion should swap in an equivalent (fade instead of movement, static frame instead of nothing) — explicit in [Pope Tech](https://blog.pope.tech/2025/12/08/design-accessible-animation-and-movement/) and the 2.3.3 guidance ([W3C Understanding 2.3.3](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html)).
+
+**Recommended control for this hero** (fits the brand): a small **hourglass/alembic icon button** in the hero's corner — `aria-pressed`, labeled "Pause background" / "Resume background," ≥24×24 px target, visible on a scrim chip so it meets contrast on the animated field. It gates the rAF loop; state persists in `localStorage`; initial state = `prefers-reduced-motion` query. Also stop on `visibilitychange` and when the hero exits the viewport (IntersectionObserver) — the Stripe off-screen-disable pattern ([bram.us](https://www.bram.us/2021/10/13/how-to-create-the-stripe-website-gradient-effect/)).
+
+```js
+const q = matchMedia('(prefers-reduced-motion: reduce)');
+let running = !q.matches && localStorage.getItem('hero-motion') !== 'off';
+function frame(t){ if (!running || document.hidden) return; step(t); requestAnimationFrame(frame); }
+btn.addEventListener('click', () => {
+  running = !running; btn.setAttribute('aria-pressed', String(!running));
+  localStorage.setItem('hero-motion', running ? 'on' : 'off');
+  if (running) requestAnimationFrame(frame); else renderPremiumStill();
+});
+q.addEventListener('change', e => { if (e.matches) { running = false; renderPremiumStill(); } });
+```
+
+**No-JS fallback:** the canvas sits inside a hero whose CSS background is a pre-rendered AVIF/WebP still of the *same scene at the same seed* (plus a pure-CSS layered-gradient approximation beneath it for the no-image case). With deterministic seeding this also keeps the site's baseline-determinism invariant intact.
+
+**Text legibility:** keep peak gold luminance out of the headline zone (mask the field's brightness with a rounded-rect falloff behind the text block, or a #211C30 scrim at 60–75 %); verify 4.5:1 for body/subtitle per [WCAG 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) against the *brightest attainable* background pixel, not the average.
+
+---
+
+## 6. Constraint compliance matrix (all six concepts)
+
+| Constraint | A Solve/Coagula | B Prima Materia | C Reaction-Diffusion | D Chladni | E Runic Ashfall | F Quicksilver |
+|---|---|---|---|---|---|---|
+| First-party only | Canvas2D ✓ | raw WebGL ✓ | raw WebGL (needs half-float FBO) ✓ | Canvas2D ✓ | either ✓ | raw WebGL ✓ |
+| 2.2.2 story | episodic ≤5 s or pause ✓✓ | pause + freeze-t ✓ | episodic by construction ✓✓✓ | episodic ✓✓✓ | pause ✓ | pause ✓ |
+| Reduced-motion substitute | static long-exposure figure | frozen seed frame | pre-converged pattern | settled figure | static rune field | merged still |
+| No-JS still | pre-rendered figure | pixel-identical AVIF | pre-rendered pattern | pre-rendered figure | pre-rendered inscription | pre-rendered pool |
+| Perf bound | O(N particles) | fixed/pixel, <1 ms-class | fixed steps, converges & stops | O(N particles) | O(cells) | fixed/pixel |
+| Vestibular risk | low (local swirl) | lowest (color-only) | lowest (growth) | low (settle) | lowest (cell twinkle) | low (slow drift) |
+| Cliché distance | max | high | max | max | high | medium |
+
+---
+
+## 7. Do-not-do list
+
+- **No proximity-line linking, in any reskin.** Gold lines instead of white lines is still particles.js.
+- **No warp/zoom/parallax starfield rehab** — high vestibular risk + the exact aesthetic being escaped.
+- **No Stripe-style gradient mesh as the main idea** — it is another brand's signature and a UI-kit commodity.
+- **No full Navier-Stokes fluid as the whole hero** — heaviest option, battery-hostile on mobile, and the Dobryakov demo is its own cliché tier now; if ink is wanted, curl-advected dye gives 80 % for 20 % of the cost.
+- **No relying on `prefers-reduced-motion` alone for 2.2.2** — unsettled even inside the WCAG WG ([#4319](https://github.com/w3c/wcag/issues/4319)); ship the control.
+- **No animated grain/flicker under reduced motion; no >5 s post-input decay** (2.2.2 re-binds once motion outlives the interaction).
+- **No fake text reaching the accessibility tree** (Concept E: `aria-hidden`, `pointer-events:none`).
+- **No gold veining/dither sparkle directly under the headline** — scrim or luminance-mask the text zone; AA against brightest pixel.
+- **No unbounded particle counts / DPR-naive buffers** — cap by viewport × DPR, halve on low-core devices, stop when hidden/off-screen.
+
+---
+
+## 8. Source index
+
+**Cliché/homogenization:** [particles.js](https://particles.js.org/) · [cssscript on particles.js ubiquity](https://www.cssscript.com/canvas-particle-animation/) · [speckyboy particle round-up](https://speckyboy.com/particle-animation-code-snippets/) · [Wheels Up Collective "Beige Internet"](https://www.wheelsupcollective.com/post/we-dont-want-a-beige-internet) · [Design Shack background trends 2025](https://designshack.net/articles/trends/background-design-trends/) · [Grainient packs](https://grainient.supply/collections/hero-gradients) · [Aceternity gradient hero block](https://ui.aceternity.com/blocks/hero-sections/modern-hero-with-gradients)
+**Algorithms:** [IQ domain warping](https://iquilezles.org/articles/warp/) · [IQ voronoi edges](https://iquilezles.org/articles/voronoilines/) · [IQ cellular ffx](https://iquilezles.org/articles/cellularffx/) · [Book of Shaders ch.12](https://thebookofshaders.com/12/) · [Emil Dziewanowski curl noise](https://emildziewanowski.com/curl-noise/) · [Chris Arasin curl dots (Canvas2D)](https://chrisarasin.com/curl-noise-dots/) · [Sighack Perlin fields](https://sighack.com/post/getting-creative-with-perlin-noise-fields/) · [varun.ca noise](https://varun.ca/noise/) · [clicktorelease flow-field lines](https://www.clicktorelease.com/code/generative-lines-flow-fields/) · [Jamie Wong metaballs](https://jamie-wong.com/2016/07/06/metaballs-and-webgl/) · [Codrops 2D metaballs WebGL2](https://tympanus.net/codrops/2021/01/19/drawing-2d-metaballs-with-webgl2/) · [pmneila Gray-Scott](https://pmneila.github.io/jsexp/grayscott/) · [piellardj reaction-diffusion](https://piellardj.github.io/reaction-diffusion-webgl/) · [xmorphia parameter atlas](https://www.mrob.com/pub/comp/xmorphia/index.html) · [CymaVis cymatics](https://cymavis.com/) · [Shadertoy Chladni](https://www.shadertoy.com/view/3tsSDr) · [Shadertoy Auroras](https://www.shadertoy.com/view/XtGGRt) · [Shadertoy domain-warped fBm](https://www.shadertoy.com/view/wttXz8)
+**Technique guides:** [Codrops Bayer dithering backgrounds](https://tympanus.net/codrops/2025/07/30/interactive-webgl-backgrounds-a-quick-guide-to-bayer-dithering/) · [Maxime Heckel dithering/retro shading](https://blog.maximeheckel.com/posts/the-art-of-dithering-and-retro-shading-web/) · [Codrops real-time dithering shader](https://tympanus.net/codrops/2025/06/04/building-a-real-time-dithering-shader/) · [Codrops Efecto ASCII/dither/CRT](https://tympanus.net/codrops/2026/01/04/efecto-building-real-time-ascii-and-dithering-effects-with-webgl-shaders/) · [Codrops ASCII shader OGL](https://tympanus.net/codrops/2024/11/13/creating-an-ascii-shader-using-ogl/) · [Codrops mouse flowmap deformation](https://tympanus.net/codrops/2019/09/25/mouse-flowmap-deformation-with-ogl/) · [Codrops interactive hover effects](https://tympanus.net/codrops/2020/04/14/interactive-webgl-hover-effects/) · [mattdesl glsl-film-grain](https://github.com/mattdesl/glsl-film-grain) · [maximmcnair film grain](https://maximmcnair.com/p/webgl-film-grain) · [fxhash grain article](https://www.fxhash.xyz/article/all-about-that-grain) · [bram.us Stripe gradient how-to](https://www.bram.us/2021/10/13/how-to-create-the-stripe-website-gradient-effect/) · [minigl gist](https://gist.github.com/jordienr/64bcf75f8b08641f205bd6a1a0d4ce1d) · [PavelDoGreat fluid sim](https://github.com/PavelDoGreat/WebGL-Fluid-Simulation) · [Larkworthy ink](https://observablehq.com/@tomlarkworthy/ink) · [john-smith.me parallax starfield](https://www.john-smith.me/parallax-starfield-and-texture-mask-effect-in-webgl.html) · [rocket-boots webgl-starfield](https://github.com/rocket-boots/webgl-starfield)
+**Award-scene case studies:** [Igloo Inc SOTD/SOTY](https://www.awwwards.com/sites/igloo-inc) · [Igloo Inc case study](https://www.awwwards.com/igloo-inc-case-study.html) · [Igloo crystal-growth writeup](https://www.webgpu.com/showcase/igloo-inc-procedural-crystals/) · [UntilLabs living particles (Codrops)](https://tympanus.net/codrops/2025/12/10/simulating-life-in-the-browser-creating-a-living-particle-system-for-the-untillabs-website/) · [Awwwards shaders editorial](https://www.awwwards.com/the-rise-of-shaders-filters-and-effects-in-web-projects.html) · [Awwwards WebGL gallery](https://www.awwwards.com/websites/webgl/) · [godly.website](https://godly.website/) · [land-book.com](https://land-book.com/)
+**Accessibility:** [W3C Understanding 2.2.2](https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html) · [W3C Understanding 2.3.3](https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html) · [W3C Understanding 1.4.3](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) · [w3c/wcag#4319](https://github.com/w3c/wcag/issues/4319) · [w3c/wcag#3766](https://github.com/w3c/wcag/issues/3766) · [CSS-Tricks WCAG animation explained](https://css-tricks.com/accessible-web-animation-the-wcag-on-animation-explained/) · [Pope Tech accessible animation](https://blog.pope.tech/2025/12/08/design-accessible-animation-and-movement/) · [web.dev motion](https://web.dev/learn/accessibility/motion) · [Smashing reduced-motion design](https://www.smashingmagazine.com/2020/09/design-reduced-motion-sensitivities/) · [WWU pause pattern](https://marcom.wwu.edu/accessibility/guide/pause-stop-hide-animation) · [Craft CMS reduced motion](https://craftcms.com/blog/designing-for-reduced-motion) · [a11y with Lindsey](https://www.a11ywithlindsey.com/blog/reducing-motion-improve-accessibility/) · [Design System Problems pause controls](https://designsystemproblems.com/accessibility-compliance/animation-pause-controls/)

--- a/.spectra/changes/hero-transmutation/change.json
+++ b/.spectra/changes/hero-transmutation/change.json
@@ -1,0 +1,12 @@
+{
+  "esl_version": "1.1",
+  "change_id": "hero-transmutation",
+  "status": "verified",
+  "tier": "full",
+  "maker": "opus-orchestrator",
+  "checker": "kupo",
+  "acceptance_checks": [],
+  "spec_ref": ".spectra/changes/hero-transmutation/spec.yaml",
+  "drift_checked": true,
+  "has_code": true
+}

--- a/.spectra/changes/hero-transmutation/spec.md
+++ b/.spectra/changes/hero-transmutation/spec.md
@@ -1,0 +1,62 @@
+# Change `hero-transmutation` — Hero rework: "Solve et Coagula" particle transmutation
+
+**Tier:** full (right_size 5 files / rubric 8 / tradeoff present). Machine-readable
+contract + acceptance checks live in `spec.yaml`; this is the narrative. Verification is
+objective-gate-based (see §4).
+
+**Maker:** opus-orchestrator · **Checker:** kupo · **Branch:** `rework/home-atelier`
+**Research of record:** `.claude/rebrand/research-hero-backgrounds.md` (Fable deep research).
+
+## 1. Context
+
+The `home-atelier` hero (starfield + nebula + cursor-proximity **constellation** lines)
+drew the owner's verdict: *"almost no animation"* and *"looks like every canvas tutorial
+on the internet."* That is accurate — particle-line linking is the single most-copied
+canvas effect (particles.js/tsParticles), and a drifting starfield is the first canvas
+tutorial anyone writes. Fable's deep research mapped the cliché and recommended **Concept
+A (particle transmutation onto the site's own sigils)** grounded on **Concept B (dithered
+prima-materia field)**. Full creative authority was granted, including the sigils.
+
+## 2. What changed
+
+- **The constellation is deleted at the root** — no proximity lines in any reskin, and
+  the starfield is retired (research §7 "do-not-do").
+- **`observatory.js` is a new engine**: first-party value/curl noise advects a few
+  thousand motes that **dissolve** into divergence-free turbulence (*solve*) and
+  **condense** onto alchemical figures rasterised from the site's own sigil geometry
+  (*coagula*) — the motto, enacted. Figures cycle on click (alchemy circle → the five
+  elements → runes). Colour shifts violet↔gold across the stages.
+- **The sigils are transformed, not kept**: the DOM alchemy-circle + static element
+  sigils + Nordic runes are **removed from markup** and re-expressed as living dust.
+- **Ground**: a static nigredo slab with a warm gold heart under the figure, finished
+  with a broken-up Bayer dither (grain, not a mesh) — the 16-bit-era texture that reads
+  as *authored*, escaping the "AI-slop purple-gradient" signature (research §1.4).
+- **Interaction is material**, never diagrammatic: the pointer stirs the dissolved
+  matter and scatters the resting dust (which re-gathers); it never fights coagulation.
+- **`home.js`** is gutted to the Konami bridge (grand-work flare + "Solve et Coagula"
+  reveal). Layout reworked to content-right / figure-left (mobile: figure top, content
+  bottom; the fixed trademark is hidden on phones to avoid a social-row collision).
+
+## 3. Accessibility (unchanged discipline)
+
+No-motion-first; one condense on load then a resting opacity breath; the HUD's pause
+control is the WCAG 2.2.2 mechanism (prefers-reduced-motion alone does not discharge it);
+reduced-motion renders the coagulated figure as a **static long-exposure** still (not a
+blank); pointer motion is user-initiated (2.3.3) and decays; canvas is `aria-hidden` +
+`pointer-events:none`; bounded particle budget + `visibilitychange` stop + seeded PRNG.
+
+## 4. Verification (all green — see `spec.yaml` gate_status)
+
+`bundle exec jekyll build` (0) · `npm run test:a11y-static` (0 — incl. token-usage,
+contrast, motion, dead-class, clamp, text-spacing, a11y-page) · `npm run test:axe` (0
+violations across all pages, light + dark) · Playwright behaviour probe with screenshot
+review (load-condense / rest / click solve→coagula→next-sigil / reduced-motion still /
+Konami / mobile + desktop composition); 0 JS errors.
+
+## 5. Scope / out of scope
+
+Touches `assets/js/observatory.js`, `assets/js/home.js`, `index.html`,
+`_sass/pages/_home.scss`, `_data/palette-manifest.yml`. Other pages untouched. The
+`_about.scss` global `.hero__content { flex: 1 }` leak is overridden with a `body.home`
+scoped rule rather than modifying the About page. `scripts/baselines/` (gitignored) will
+need a local `test:visual --update` for the intentional redesign — not a CI gate.

--- a/.spectra/changes/hero-transmutation/spec.yaml
+++ b/.spectra/changes/hero-transmutation/spec.yaml
@@ -1,0 +1,121 @@
+# spec.yaml — ESL machine-readable contract for change `hero-transmutation`.
+artifact: spec
+change_id: hero-transmutation
+tier: full
+version: 0.1.0
+maker: opus-orchestrator
+checker: kupo
+title: "Hero rework — Solve et Coagula particle transmutation"
+branch: rework/home-atelier
+supersedes_visual: home-atelier   # replaces the atelier's starfield/constellation hero
+complexity:
+  score: 8
+  verdict: extended
+research_of_record: .claude/rebrand/research-hero-backgrounds.md   # Fable deep-research; Concept A over B
+context: >-
+  The atelier hero (starfield + nebula + cursor-proximity constellation lines)
+  read as generic — the owner's verdict: "almost no animation" and "looks like
+  every canvas tutorial on the internet." Proximity-line linking is THE
+  canvas-tutorial cliché (particles.js/tsParticles). Fable's deep research
+  recommended Concept A (particle transmutation onto the site's own sigils)
+  grounded on Concept B (dithered prima-materia field). Full creative authority
+  granted, including removing/modifying the sigils.
+acceptance_checks:
+- id: AC-T01
+  given: proximity-line linking ("constellation") is the cliché under indictment
+  when: the hero is reworked
+  then: the mechanic SHALL be removed at the root — no line-linking in any reskin,
+    and the starfield retired
+  verify_method: observatory.js contains no line-drawing between particles; old
+    starfield/constellation code deleted
+- id: AC-T02
+  given: the motto is "Solve et Coagula"
+  when: the field animates
+  then: particles SHALL dissolve into divergence-free curl-noise turbulence (solve)
+    and condense onto rasterised sigil geometry (coagula), cycling figures on click
+  verify_method: Playwright — load condenses the alchemy circle; click dissolves
+    (violet swirl w/ trails) then re-condenses the next sigil (fire)
+- id: AC-T03
+  given: the sigils were static DOM/SVG clip-art
+  when: the rework ships
+  then: the DOM alchemy-circle + element sigils + runes SHALL be removed from markup
+    and rendered as living dust instead
+  verify_method: grep _site/index.html — 0 .alchemy-circle / .alchemy-symbol / .rune
+- id: AC-T04
+  given: an auto-drifting field would auto-start continuous motion
+  when: prefers-reduced-motion:reduce
+  then: the canvas SHALL paint the coagulated figure as a STATIC long-exposure still
+    (no rAF), FPS readout '—', toggle offering resume (no-motion-first + substitution)
+  verify_method: Playwright reducedMotion:'reduce' — static figure, isRunning()===false
+- id: AC-T05
+  given: the resting figure breathes (continuous opacity motion)
+  when: motion is on
+  then: the HUD SHALL provide the WCAG 2.2.2 pause/resume control (prefers-reduced-motion
+    alone does not discharge 2.2.2), persisted, initialised from the OS preference
+  verify_method: toggle has aria-pressed + aria-label; axe 0 violations on Home
+- id: AC-T06
+  given: cursor-line linking is diagrammatic; award heroes respond materially
+  when: the pointer moves over the hero
+  then: the response SHALL be material (stir during solve, scatter-then-regather at
+    rest) and SHALL never fight coagulation, so the figure always forms cleanly
+  verify_method: stepParticles skips pointer force when phase==='coagula'; canvas is
+    pointer-events:none (never intercepts links)
+- id: AC-T07
+  given: a smooth violet field risks the "AI-slop" purple-gradient signature
+  when: the ground renders
+  then: it SHALL be a nigredo slab finished with a broken-up Bayer dither (grain, not
+    mesh), static (zero vestibular cost)
+  verify_method: drawGround/ditherGround run once per resize; screenshots show grain
+- id: AC-T08
+  given: a continuous canvas loop could peg CPU/battery
+  when: the loop runs
+  then: it SHALL bound the particle budget (<=2600), stop on visibilitychange, and use
+    a seeded PRNG so the still is deterministic
+  verify_method: particleBudget cap; document 'visibilitychange' -> stop(); seeded hash
+- id: AC-T09
+  given: gold veining/dust must not harm headline legibility
+  when: text sits over the ground
+  then: hero title/subtitle/tagline SHALL meet WCAG AA (effect massed left, text right)
+  verify_method: npm run test:axe — color-contrast 0 violations on Home, light + dark
+- id: AC-T10
+  given: the effect must degrade without JS
+  when: JavaScript is off
+  then: the hero SHALL show its layered-gradient background with no empty canvas
+  verify_method: canvases are created by observatory.js; .alchemist-hero has a CSS bg
+- id: AC-T11
+  given: the project's a11y gates must stay green
+  when: the suites run
+  then: test:a11y-static and test:axe SHALL exit 0 (incl. motion: no infinite outside
+    motion-ok; clamp: max/min<=2.5 + rem-anchored middle)
+  verify_method: npm run test:a11y-static (exit 0); npm run test:axe (PASS)
+- id: AC-T12
+  given: prior invariants must not regress
+  when: the homepage renders
+  then: the footer disclaimer SHALL remain in the DOM (AC-020) and the Konami spell
+    SHALL still reveal "Solve et Coagula"
+  verify_method: grep footer__disclaimer==1; home.js Konami -> Observatory.flare + reveal
+gates_must_stay_green:
+- npm run test:a11y-static
+- npm run test:axe
+non_ci_safety_net:
+- gate: npm run test:visual
+  note: not a CI gate; index baseline will need a refresh (intentional redesign).
+    Ground + still are deterministic (seeded PRNG); other pages unaffected.
+files_touched:
+- assets/js/observatory.js   # full rewrite — transmutation engine
+- assets/js/home.js          # gutted to the Konami bridge
+- index.html                 # removed DOM alchemy-circle + sigils
+- _sass/pages/_home.scss     # removed dead circle/symbol styling; content-right layout
+- _data/palette-manifest.yml # removed obsolete .alchemy-symbol/.rune exemption
+gate_status:
+  build: bundle exec jekyll build exit 0
+  test_a11y_static: PASS (exit 0)
+  test_axe: PASS (0 violations across all pages, light + dark)
+  test_motion: PASS (AC-031; 0 "infinite" in the new JS)
+  visual_behavior_probe: PASS (load-condense / rest / click solve->coagula / reduced still); 0 JS errors
+  confidence:
+    score: 84
+    verdict: VALIDATE
+    note: AUTHOR-SCORED. Verification is objective-gate-based (deterministic scripts +
+      headless axe + Playwright behaviour probe with screenshot review). Checker role
+      (kupo) is sandbox-scoped without npm/node, so the orchestrator ran the gates.

--- a/.spectra/changes/home-atelier/change.json
+++ b/.spectra/changes/home-atelier/change.json
@@ -1,0 +1,12 @@
+{
+  "esl_version": "1.1",
+  "change_id": "home-atelier",
+  "status": "verified",
+  "tier": "full",
+  "maker": "opus-orchestrator",
+  "checker": "kupo",
+  "acceptance_checks": [],
+  "spec_ref": ".spectra/changes/home-atelier/spec.md",
+  "drift_checked": true,
+  "has_code": true
+}

--- a/.spectra/changes/home-atelier/spec.md
+++ b/.spectra/changes/home-atelier/spec.md
@@ -1,0 +1,81 @@
+# Change `home-atelier` — Homepage rework: The Alchemist's Observatory
+
+**Tier:** full (right_size 5 files / rubric 7 / tradeoff present) — spec kept lean;
+verification leans on the repo's automated gates (contrast / motion / axe / visual
+baseline) rather than heavy critic ceremony, per the owner's direct creative dispatch.
+
+**Maker:** opus-orchestrator · **Checker:** kupo · **Branch:** `rework/home-atelier`
+(chained off `normalize/tokens`, PR #65).
+
+## 1. Context
+
+The homepage is a "Code Alchemist" hero: an interactive alchemy circle (drag-to-rotate
+orbital rings, floating alchemical element sigils + Nordic runes) over a dark purple
+gradient, followed by *Recent Scrolls* and *Favorites from the Grimoire* sections.
+
+Two problems motivate the rework:
+
+1. **Latent unreachable content (defect).** `body.home { position: fixed; overflow:
+   hidden }` locks the homepage to a single viewport, yet the Scrolls/Favorites sections
+   live below the fold — they are in the DOM but unreachable by scroll today.
+2. **Astonish ceiling.** The hero is handsome but static-feeling; the owner wants the
+   earendil.com quality of a *live-rendered* ambient background and *discoverable,
+   non-obstructive* interactivity ("enjoyable once they find out").
+
+## 2. Owner decisions (this session)
+
+- **D1 — Single-screen atelier.** Keep the homepage a single immersive locked viewport
+  (no scroll). Resolve the defect by *removing* the Scrolls/Favorites sections from the
+  homepage; those posts stay discoverable via nav → Notebook and the sitewide footer.
+- **D2 — Living nebula background.** A performant canvas layer behind the hero: drifting
+  stardust + soft nebula clouds, pointer parallax. One static frame under
+  `prefers-reduced-motion`.
+- **D3 — Signature interactions:** (a) *Living constellation* — pointer draws nearby
+  motes into slow orbit; faint constellation lines form and fade. (b) *Dev homage* — a
+  subtle FPS readout, a styled console sigil/greeting, and a Konami rune-cipher easter
+  egg with a one-shot transmutation payoff. (The "Great Work" gamified sequence was
+  considered and declined.)
+
+## 3. Scope
+
+**Touches:** `index.html`, `_sass/pages/_home.scss`, `assets/js/home.js`, new
+`assets/js/observatory.js` (ambient canvas engine), and this change folder.
+
+**Preserves (personal brand — do not "normalize away"):** the alchemy circle centerpiece
+and its drag/sigil interactions, the RPG/alchemy ubiquitous vocabulary (scrolls, sigils,
+runes, grimoire), hero name/subtitle/tagline/social row, the trademark line.
+
+## 4. Acceptance checks (EARS)
+
+- **AC-A01** — WHERE a visitor loads the homepage, THE hero SHALL fill exactly one
+  viewport with no vertical scroll (single-screen atelier preserved).
+- **AC-A02** — THE homepage SHALL NOT render the Recent Scrolls or Favorites sections;
+  those posts SHALL remain reachable via the main nav (Notebook) and the sitewide footer.
+- **AC-A03** — WHEN `prefers-reduced-motion: reduce` is set, THE ambient canvas SHALL
+  render a single static frame and start NO continuous animation loop (WCAG 2.2.2 /
+  AC-024 lineage).
+- **AC-A04** — WHERE motion is permitted, every auto-starting hero animation SHALL remain
+  finite (≤5s, non-infinite iteration count) — no regression of AC-031.
+- **AC-A05** — WHEN the pointer moves over the hero, THE nebula/constellation SHALL
+  parallax toward the pointer, AND THE canvas SHALL set `pointer-events: none` so it never
+  intercepts clicks on hero content or links.
+- **AC-A06** — THE FPS readout SHALL be `aria-hidden="true"` and SHALL NOT be announced to
+  assistive technology.
+- **AC-A07** — WHEN the visitor enters the Konami sequence (↑↑↓↓←→←→ B A), THE page SHALL
+  play a one-shot transmutation flourish AND SHALL NOT alter navigation or content state.
+- **AC-A08** — THE alchemy circle SHALL remain drag-to-rotate AND its element/rune sigils
+  SHALL remain hover/tap interactive (no regression of existing behavior).
+- **AC-A09** — THE hero title, subtitle, tagline, and any visible readout text SHALL meet
+  WCAG AA contrast (≥4.5:1) against their background — no regression of the
+  palette-contrast gate.
+- **AC-A10** — THE canvas loop SHALL cap its work: bounded mote budget, and it SHALL
+  pause via `visibilitychange` when the tab is hidden, so it does not peg the CPU.
+- **AC-A11** — THE footer include SHALL remain present in the homepage DOM (AC-020
+  sitewide-disclaimer no-regression).
+
+## 5. Out of scope
+
+- Other pages (About, Notebook, Laboratory, Letter) — untouched.
+- The "Great Work" gamified transmutation sequence (declined by owner).
+- No new third-party requests (self-hosted-fonts / cookie-free invariant preserved; the
+  canvas engine is first-party vanilla JS, no libraries).

--- a/.spectra/changes/home-atelier/spec.yaml
+++ b/.spectra/changes/home-atelier/spec.yaml
@@ -1,0 +1,114 @@
+# spec.yaml — ESL machine-readable contract for change `home-atelier`.
+artifact: spec
+change_id: home-atelier
+tier: full
+version: 0.1.0
+maker: opus-orchestrator
+checker: kupo
+title: "Homepage rework — The Alchemist's Observatory"
+branch: rework/home-atelier
+chained_off: normalize/tokens
+complexity:
+  score: 7
+  verdict: extended
+depends_on:
+- normalize
+criteria_source: .spectra/changes/home-atelier/spec.md
+owner_decisions:
+- id: D1
+  decision: Single-screen atelier — keep the homepage one immersive locked viewport;
+    remove the below-fold Recent Scrolls + Favorites sections (they were in the DOM
+    but unreachable under body.home position:fixed/overflow:hidden). Posts stay
+    reachable via nav → Notebook and the sitewide footer.
+- id: D2
+  decision: Living nebula background — a first-party canvas layer (drifting stardust
+    + soft nebula, tiny local pointer reactivity). One static frame under reduced motion.
+- id: D3
+  decision: Signature interactions — living constellation + dev homage (FPS readout,
+    console sigil, Konami transmutation). The gamified "Great Work" sequence was declined.
+acceptance_checks:
+- id: AC-A01
+  given: the homepage was a scroll-locked hero with content stranded below the fold
+  when: a visitor loads the homepage
+  then: the hero SHALL fill one viewport with no vertical scroll (single-screen atelier)
+  verify_method: Playwright probe — getComputedStyle(body).position === 'fixed'; visual-baseline
+    index height dropped from 320x3702 to 320x1283 (below-fold sections removed)
+- id: AC-A02
+  given: Recent Scrolls + Favorites lived only on the homepage
+  when: the homepage renders
+  then: it SHALL NOT emit those sections, and the posts SHALL stay reachable via nav (Notebook) and footer
+  verify_method: grep _site/index.html — 0 '<section class="rpg-scrolls'; footer nav + Notebook link present
+- id: AC-A03
+  given: an auto-drifting starfield would otherwise auto-start continuous motion
+  when: prefers-reduced-motion:reduce is set
+  then: the canvas SHALL paint one static frame and start NO rAF loop (no-motion-first; WCAG 2.2.2/AC-024 lineage)
+  verify_method: Playwright reducedMotion:'reduce' — FPS readout shows '—', toggle aria-label='Play ambient motion'
+- id: AC-A04
+  given: AC-031 made hero animations finite
+  when: motion is permitted
+  then: every auto-starting hero animation SHALL stay finite (<=5s, non-infinite iteration)
+  verify_method: npm run test:motion exits 0 (grep "infinite" outside motion-ok = 0)
+- id: AC-A05
+  given: the canvas overlays the hero
+  when: the pointer moves over the hero
+  then: the nebula/constellation SHALL react locally AND the canvas SHALL be pointer-events:none (never intercept clicks)
+  verify_method: CSS .observatory { pointer-events:none }; axe target-size + focusable checks pass on Home
+- id: AC-A06
+  given: the FPS readout is decorative
+  when: assistive tech reads the page
+  then: the readout SHALL be aria-hidden and not announced
+  verify_method: observatory.js sets aria-hidden='true' on the fps span; axe 0 violations on Home
+- id: AC-A07
+  given: a hidden spell should reward the curious
+  when: the Konami sequence (↑↑↓↓←→←→ B A) is entered
+  then: a one-shot transmutation flourish SHALL play with NO navigation/content-state change
+  verify_method: Playwright key sequence — .transmutation-reveal appears with motto 'Solve et Coagula'; URL unchanged
+- id: AC-A08
+  given: the alchemy circle is the personal-brand centerpiece
+  when: the rework ships
+  then: the circle SHALL remain drag-to-rotate and its sigils hover/tap interactive (no regression)
+  verify_method: home.js circle drag + symbol handlers retained verbatim; manual/probe confirms
+- id: AC-A09
+  given: AC-047 forbids ornament tokens as text color on declared light backgrounds
+  when: the reveal renders light-on-dark
+  then: reveal text SHALL meet AA on its own dark scrim (documented, measured exemptions)
+  verify_method: npm run test:token-usage exits 0; measured --ff-gold 7.75/6.38, $background-cream 15.18/12.49 vs hero stops
+- id: AC-A10
+  given: a continuous canvas loop could peg the CPU
+  when: the loop runs
+  then: it SHALL bound the mote budget AND pause on visibilitychange when the tab is hidden
+  verify_method: observatory.js starBudget cap (<=150) + document 'visibilitychange' -> stop(); code review
+- id: AC-A11
+  given: AC-020 requires the sitewide disclaimer on every page
+  when: the homepage renders
+  then: the footer include SHALL remain present in the homepage DOM
+  verify_method: grep _site/index.html footer__disclaimer == 1
+gates_must_stay_green:
+- npm run test:a11y-static   # manifest, token-usage, contrast, rarity, motion, dark-cascade, dead-class, clamp, text-spacing, a11y-page
+- npm run test:axe           # headless Playwright + axe-core, all pages
+non_ci_safety_net:
+- gate: npm run test:visual
+  note: not a CI gate; index baseline refreshed for the intentional redesign. Starfield
+    seeded (mulberry32) so the reduced-motion static frame is byte-deterministic; all
+    other pages verified 0.0000% pixel drift.
+files_touched:
+- index.html
+- assets/js/observatory.js   # new — ambient canvas engine + HUD + console homage
+- assets/js/home.js          # + Konami transmutation (existing circle interactions preserved)
+- _sass/pages/_home.scss     # observatory/HUD/transmutation styling
+- _data/palette-manifest.yml # 2 documented, measured usage_exemptions for the dark-surface reveal text
+gate_status:
+  esl_verify: pending transition; C1/C2a/C2b pass, C3 satisfied by this spec.yaml
+  build: bundle exec jekyll build exit 0
+  test_a11y_static: PASS (0 failures)
+  test_axe: PASS (0 violations across Home/About/Notebook/Laboratory/Letter, light + dark)
+  test_motion: PASS (AC-031)
+  visual_behavior_probe: PASS (default loop 60fps; reduced static 'FPS —'; Konami reveal 'Solve et Coagula')
+  visual_baseline_scope: only index changed; all other pages 0.0000% pixel drift
+  confidence:
+    score: 82
+    verdict: VALIDATE
+    note: AUTHOR-SCORED. Verification is objective-gate-based (deterministic scripts +
+      headless axe + Playwright behavior probe), not a subjective critic. The project's
+      checker role (kupo) is sandbox-scoped without npm/node access, so the orchestrator
+      ran the gate suite; all green.

--- a/_data/palette-manifest.yml
+++ b/_data/palette-manifest.yml
@@ -578,16 +578,10 @@ usage_exemptions:
       change `home-atelier`: sub-line of the same dark-surface reveal; same
       hero-gradient pairing as .hero__content, restated: 15.18:1 / 12.49:1
       (worst-case scrim-over-orb 11.96:1).
-  - file: _sass/pages/_home.scss
-    line: 352
-    selector: ".alchemy-symbol, .rune"
-    property: color
-    token: "var(--symbol-color, $pastel-purple)"
-    reason: >-
-      $pastel-purple here is a fallback for --symbol-color (out of manifest
-      scope, see not_manifest_scope) -- every actual rune element sets
-      --symbol-color inline, so the $pastel-purple fallback never renders in
-      practice. Decorative icon fill, not body text.
+  # (removed) `.alchemy-symbol, .rune` exemption: change `hero-transmutation`
+  # deleted those DOM elements + their SCSS -- the sigils are now rendered as
+  # canvas dust by observatory.js, so there is no longer a palette-token color
+  # usage to exempt.
   - file: _sass/components/_components.scss
     line: 89
     selector: ".social-icon (--linkedin/--github/--dev)"

--- a/_data/palette-manifest.yml
+++ b/_data/palette-manifest.yml
@@ -556,6 +556,29 @@ usage_exemptions:
     token: $background-cream
     reason: "Same hero-gradient pairing as .hero-content, restated: 15.18:1 / 12.49:1."
   - file: _sass/pages/_home.scss
+    line: 744
+    selector: ".transmutation-reveal__motto"
+    property: color
+    token: --ff-gold
+    reason: >-
+      change `home-atelier`: the hidden-spell (Konami) reveal is light-on-dark,
+      like the hero wordmark -- it renders on its OWN dark scrim
+      (.transmutation-reveal::before, radial rgba(20,16,30,0.82)), never a
+      declared light background. Measured against the underlying hero-gradient
+      stops (the guaranteed backdrop) at 7.75:1 / 6.38:1; the semi-transparent
+      scrim only darkens the effective bg further (worst case, scrim over the
+      bright pastel orb: 6.11:1 -- still > 4.5). The light-background
+      --ff-gold-ink would be WRONG here (a dark ink on a dark surface).
+  - file: _sass/pages/_home.scss
+    line: 752
+    selector: ".transmutation-reveal__sub"
+    property: color
+    token: $background-cream
+    reason: >-
+      change `home-atelier`: sub-line of the same dark-surface reveal; same
+      hero-gradient pairing as .hero__content, restated: 15.18:1 / 12.49:1
+      (worst-case scrim-over-orb 11.96:1).
+  - file: _sass/pages/_home.scss
     line: 352
     selector: ".alchemy-symbol, .rune"
     property: color

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -1,11 +1,19 @@
 // ==========================================================================
-// ALCHEMIST HOME PAGE STYLES
+// ALCHEMIST HOME PAGE — "Solve et Coagula" transmutation hero
+// (change `hero-transmutation`)
+//
+// The whole left-of-hero apparatus (alchemy circle, orbital rings, floating
+// element sigils + Nordic runes, ripple/particle DOM) is GONE from the markup:
+// those glyphs are now rasterised and rendered as living dust by
+// observatory.js. This partial styles the hero chrome (text, HUD, reveal) and
+// the two canvas layers; it deliberately no longer carries any of the old
+// `.alchemy-circle` / `.alchemy-symbol` / `.rune` CSS.
 // ==========================================================================
 
 @use "../settings/variables" as *;
 @use "../tools/breakpoints" as *;
 
-// Prevent scrolling on home page
+// Single-screen lock (unchanged): the homepage is one immersive viewport.
 body.home {
   overflow: hidden;
   height: 100vh;
@@ -18,86 +26,82 @@ html.home {
   height: 100%;
 }
 
+html, body {
+  overflow-x: hidden;
+}
+
+// The hero shell. Its `background` is the no-JS fallback (a layered violet slab
+// with a soft aurum glow left-of-centre, where the dust coagulates); with JS,
+// observatory.js's opaque dithered ground canvas paints over it. Content is
+// pushed to the RIGHT so the transmuting figure owns the left (research §3.5:
+// keep the effect out of the headline zone).
 .alchemist-hero {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   min-height: 100vh;
-  background: linear-gradient(135deg, #211C30, #312A45);
-  padding: 2rem;
   position: relative;
-  overflow: visible;
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image:
-      radial-gradient(circle at 20% 30%, rgba(103, 58, 183, 0.15) 0%, transparent 20%),
-      radial-gradient(circle at 80% 70%, rgba(63, 81, 181, 0.15) 0%, transparent 20%);
-    z-index: 1;
-  }
+  overflow: hidden;
+  // clamp: max/min <= 2.5 and a rem-anchored middle term (AC-034 / F94).
+  padding: 2rem clamp(2.5rem, 1.5rem + 4vw, 6rem) 2rem 2rem;
+  background:
+    radial-gradient(ellipse 42% 55% at 31% 52%, rgba(103, 58, 183, 0.28), transparent 72%),
+    radial-gradient(circle at 24% 62%, rgba(230, 165, 83, 0.06), transparent 55%),
+    linear-gradient(135deg, #1c1830, #241f3a);
 
   @include max-width('lg') {
     flex-direction: column;
-    padding: 2rem 1rem;
-    min-height: auto;
-    padding-top: 4rem;
-    padding-bottom: 4rem;
-  }
-
-  @include max-width('sm') {
-    padding: 2rem 1rem;
-    min-height: calc(100vh - 4rem);
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0 1.5rem 13vh; // comfortable bottom breathing room on the locked screen
+    min-height: 100vh;
+    background:
+      radial-gradient(ellipse 66% 28% at 50% 26%, rgba(103, 58, 183, 0.3), transparent 72%),
+      linear-gradient(160deg, #1c1830, #241f3a);
   }
 }
 
-/* Hero Content */
+// Hero content — right-aligned block on desktop, lower-centre on narrow screens.
 .hero__content {
-  flex: 1;
-  max-width: 600px;
-  margin-left: 2rem;
-  margin-right: 4rem;
+  max-width: 540px;
+  width: 100%;
   position: relative;
   z-index: 3;
   color: $background-cream;
 
   @include max-width('lg') {
-    margin: 2rem 0 0 0;
     text-align: center;
     max-width: 100%;
   }
+}
 
-  @include max-width('sm') {
-    margin: 1.5rem 0 0 0;
-  }
+// _about.scss leaks a global `.hero__content { flex: 1 }` (imported AFTER this
+// partial, so it wins the cascade). On the home column layout that stretches
+// the content to full viewport height and strands the text at the top with the
+// figure overlapping it. Scope + specificity (body.home) override it so the
+// home content keeps its natural height: it then sits at flex-end — the bottom
+// on mobile, the right on desktop.
+body.home .hero__content {
+  flex: 0 1 auto;
 }
 
 .hero__title {
-  font-size: 3.5rem;
+  font-size: clamp(2.5rem, 1.6rem + 3.4vw, 3.75rem);
   margin-bottom: 0.5rem;
   color: $background-cream;
   font-weight: 700;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-
-  @include max-width('sm') {
-    font-size: 2.5rem;
-  }
+  letter-spacing: -0.01em;
+  text-shadow: 0 2px 12px rgba(0, 0, 0, 0.45);
 }
 
 .hero__subtitle {
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 1rem + 1.8vw, 2rem);
   margin-bottom: 1.5rem;
   color: var(--ff-gold);
   font-family: 'Nothing You Could Do', cursive;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
 
-  @include max-width('sm') {
-    font-size: 1.5rem;
-  }
+  @include max-width('sm') { margin-bottom: 1rem; }
 }
 
 .hero__description {
@@ -105,6 +109,12 @@ html.home {
   margin-bottom: 2rem;
   line-height: 1.6;
   color: $pastel-blue;
+  text-shadow: 0 1px 6px rgba(0, 0, 0, 0.5);
+
+  @include max-width('sm') {
+    font-size: 1.04rem;
+    margin-bottom: 1.25rem;
+  }
 }
 
 .hero-trademark {
@@ -120,476 +130,48 @@ html.home {
   text-shadow: 0 0 10px rgba($pastel-purple, 0.3);
   z-index: 10;
 
-  &__copyright {
-    font-size: 1.1rem;
-  }
+  &__copyright { font-size: 1.1rem; }
+  &__year { font-weight: 300; }
+  &__name { font-weight: 500; }
 
-  &__year {
-    font-weight: 300;
-  }
-
-  &__name {
-    font-weight: 500;
-  }
-
+  // On phones the fixed trademark collides with the centred social row at the
+  // bottom of the single-screen hero; it's a decorative echo of the footer
+  // copyright, so hide it here rather than fight the overlap.
   @include max-width('sm') {
-    bottom: 1.5rem;
-    right: 1.5rem;
-    font-size: 0.8rem;
-  }
-}
-
-/* Alchemy Circle */
-.alchemy-circle {
-  position: relative;
-  width: 480px;
-  height: 480px;
-  margin: 0 auto;
-  z-index: 2;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  @include max-width('lg') {
-    width: 300px;
-    height: 300px;
-    margin: 0 0 2rem 0;
-  }
-
-  @include max-width('sm') {
-    width: 250px;
-    height: 250px;
-    margin: 4rem 0 1.5rem 0;
-  }
-
-  @include max-width('xs') {
-    width: 220px;
-    height: 220px;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    background: radial-gradient(
-      circle at var(--glow-x, 50%),
-      var(--glow-y, 50%),
-      rgba(205, 180, 219, 0.5) 0%,
-      transparent 70%
-    );
-    opacity: var(--glow-strength, 0);
-    transition: opacity 0.3s ease;
-    z-index: -1;
-  }
-
-  &.interacting {
-    cursor: grabbing;
-  }
-}
-
-.alchemy-circle__inner {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  background: radial-gradient(circle, $pastel-purple, #6A5687);
-  box-shadow: 0 0 25px rgba(205, 180, 219, 0.7);
-  z-index: 2;
-
-  @include max-width('sm') {
-    width: 70px;
-    height: 70px;
-  }
-
-  @include max-width('xs') {
-    width: 60px;
-    height: 60px;
-  }
-}
-
-.alchemy-circle__ring {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  border-radius: 50%;
-  border: 1.5px solid var(--ring-color, rgba(205, 180, 219, 0.3));
-  transform: translate(-50%, -50%) rotate(var(--settle-angle, 0deg));
-
-  // AC-031 / Story 4.5: was `rotate 40s|60s|80s linear infinite` -- ALL THREE
-  // conditions of WCAG 2.2.2 held (auto-starts on load, presented in
-  // parallel with the hero name/subtitle/tagline/social row, and a single
-  // rotation already took 40-80s, let alone forever). research-ui-a11y.md
-  // §3.2's cheapest reconciliation: make the loop finite and it "does not
-  // apply at all, and you owe no pause button" -- a circle that inscribes,
-  // flares, and settles is also better theater than an idle spin. Each ring
-  // settles at a fixed --settle-angle (held via `forwards`) instead of
-  // spinning forever; re-triggers naturally on every full page load, since
-  // this is a static multi-page site with no client-side routing to
-  // re-trigger against.
-  &--1 {
-    width: 180px;
-
-    height: 180px;
-    animation: circle-settle 2.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;
-    --ring-color: rgba(205, 180, 219, 0.4);
-    --settle-angle: 35deg;
-  }
-
-  &--2 {
-    width: 300px;
-    height: 300px;
-    animation: circle-settle 3.1s cubic-bezier(0.22, 1, 0.36, 1) 0.3s 1 forwards;
-    --ring-color: rgba(185, 201, 230, 0.4);
-    --settle-angle: -50deg;
-  }
-
-  &--3 {
-    width: 420px;
-    height: 420px;
-    animation: circle-settle 3.8s cubic-bezier(0.22, 1, 0.36, 1) 0.6s 1 forwards;
-    --ring-color: rgba(248, 209, 224, 0.4);
-    --settle-angle: 70deg;
-  }
-
-  @include max-width('lg') {
-    &--1 {
-      width: 120px;
-      height: 120px;
-    }
-
-    &--2 {
-      width: 200px;
-      height: 200px;
-    }
-
-    &--3 {
-      width: 280px;
-      height: 280px;
-    }
-  }
-
-  @include max-width('sm') {
-    &--1 {
-      width: 100px;
-      height: 100px;
-    }
-
-    &--2 {
-      width: 170px;
-      height: 170px;
-    }
-
-    &--3 {
-      width: 230px;
-      height: 230px;
-    }
-  }
-
-  @include max-width('xs') {
-    &--1 {
-      width: 90px;
-      height: 90px;
-    }
-
-    &--2 {
-      width: 150px;
-      height: 150px;
-    }
-
-    &--3 {
-      width: 210px;
-      height: 210px;
-    }
-  }
-}
-
-// AC-031 / Story 4.5: "inscribes, flares, and settles" -- opacity fades in,
-// a brief scale overshoot around 65% reads as the "flare," and the ring
-// comes to rest at its own --settle-angle (held via `forwards`). Every ring
-// finishes well inside 5s (see the per-ring delay+duration above); 2.2.2
-// "does not apply at all" once the loop is finite, per research-ui-a11y.md.
-@keyframes circle-settle {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, -50%) rotate(calc(var(--settle-angle, 0deg) - 90deg)) scale(0.7);
-  }
-  65% {
-    opacity: 1;
-    transform: translate(-50%, -50%) rotate(calc(var(--settle-angle, 0deg) * 0.85)) scale(1.06);
-  }
-  100% {
-    opacity: 1;
-    transform: translate(-50%, -50%) rotate(var(--settle-angle, 0deg)) scale(1);
-  }
-}
-
-/* Alchemy Symbols & Runes */
-.alchemy-symbol, .rune {
-  position: absolute;
-  width: 50px;
-  height: 50px;
-  color: var(--symbol-color, $pastel-purple);
-  filter: drop-shadow(0 0 8px var(--symbol-color, rgba(205, 180, 219, 0.5)));
-  transition: all 0.3s ease;
-  z-index: 3;
-  transform: translateY(0);
-  // AC-031: was `float 3s ease-in-out infinite` (undefined locally -- see
-  // _sass/_base.scss's drift-settle note for the cross-partial `float`
-  // keyframe collision this rode on). assets/js/home.js overrides this
-  // inline on load with a finite (2-iteration) version of `float-glyphs`;
-  // this is the no-JS / pre-hydration fallback, now finite too.
-  animation: float-glyphs 1.8s ease-in-out 2;
-
-  svg {
-    width: 100%;
-    height: 100%;
-  }
-
-  &.activated {
-    filter: brightness(2) drop-shadow(0 0 20px var(--symbol-color));
-    animation: pulse-activate 1s ease-out;
-  }
-
-  @include max-width('sm') {
-    width: 35px;
-    height: 35px;
-  }
-
-  @include max-width('xs') {
-    width: 30px;
-    height: 30px;
-  }
-}
-
-.alchemy-symbol.hovered, .rune.hovered {
-  filter: brightness(1.5) drop-shadow(0 0 12px var(--symbol-color));
-  transform: translateY(-10px) scale(1.3);
-  z-index: 5;
-  animation: none;
-
-  &::after {
-    content: attr(title);
-    position: absolute;
-    bottom: -30px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(33, 28, 48, 0.85);
-    color: var(--symbol-color);
-    padding: 0.35rem 0.75rem;
-    border-radius: 4px;
-    font-size: 0.8rem;
-    white-space: nowrap;
-    opacity: 1;
-    visibility: visible;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    z-index: 10;
-    animation: nameAppear 0.3s ease-out;
-    border: 1px solid rgba(205, 180, 219, 0.2);
-    text-shadow: 0 0 8px var(--symbol-color);
-  }
-}
-
-@keyframes float-glyphs {
-  0%, 100% {
-    transform: translateY(0);
-  }
-  25% {
-    transform: translateY(-8px);
-  }
-  50% {
-    transform: translateY(-12px);
-  }
-  75% {
-    transform: translateY(-8px);
-  }
-}
-
-@keyframes pulse-activate {
-  0% {
-    transform: scale(1);
-    opacity: 1;
-  }
-  50% {
-    transform: scale(1.5);
-    opacity: 0.8;
-  }
-  100% {
-    transform: scale(1);
-    opacity: 1;
-  }
-}
-
-@keyframes nameAppear {
-  from {
-    opacity: 0;
-    transform: translateX(-50%) translateY(5px);
-  }
-  to {
-    opacity: 1;
-    transform: translateX(-50%) translateY(0);
-  }
-}
-
-/* Position symbols with fixed classes instead of direct positioning */
-.alchemy-symbol--fire {
-  top: 15%;
-  left: 25%;
-}
-
-.alchemy-symbol--water {
-  bottom: 20%;
-  left: 20%;
-}
-
-.alchemy-symbol--air {
-  top: 20%;
-  right: 20%;
-}
-
-.alchemy-symbol--earth {
-  bottom: 25%;
-  right: 25%;
-}
-
-.alchemy-symbol--quintessence {
-  top: 50%;
-  left: 15%;
-}
-
-/* Position runes */
-.rune--ansuz {
-  top: 15%;
-  right: 15%;
-}
-
-.rune--kenaz {
-  bottom: 15%;
-  right: 15%;
-}
-
-.rune--raidho {
-  left: 50%;
-  bottom: 15%;
-}
-
-.rune--laguz {
-  top: 50%;
-  right: 15%;
-}
-
-/* Ripple effect on click */
-.alchemy-ripple {
-  position: absolute;
-  border-radius: 50%;
-  transform: scale(0);
-  background: radial-gradient(circle,
-    rgba(255, 255, 255, 0.9) 0%,
-    rgba(255, 255, 255, 0.3) 50%,
-    transparent 70%);
-  width: 200px;
-  height: 200px;
-  margin-left: -100px;
-  margin-top: -100px;
-  opacity: 0;
-  animation: ripple 1s ease-out forwards;
-  pointer-events: none;
-  box-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
-}
-
-@keyframes ripple {
-  0% {
-    transform: scale(0);
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.8;
-  }
-  100% {
-    transform: scale(1.5);
-    opacity: 0;
-  }
-}
-
-/* Accessibility improvements */
-@media (prefers-reduced-motion: reduce) {
-  .alchemy-circle__ring {
-    animation: none;
-  }
-
-  .alchemy-circle {
-    transition: none;
-  }
-
-  .alchemy-symbol, .rune {
-    transition: none;
-    animation: none;
-  }
-}
-
-html, body {
-  overflow-x: hidden;
-}
-
-/* Particle effects */
-.alchemy-particle {
-  position: absolute;
-  width: 4px;
-  height: 4px;
-  background: white;
-  border-radius: 50%;
-  pointer-events: none;
-  animation: particle-fade 1s ease-out forwards;
-  box-shadow: 0 0 10px white;
-}
-
-@keyframes particle-fade {
-  0% {
-    transform: translate(0, 0) scale(1);
-    opacity: 1;
-  }
-  100% {
-    transform: translate(var(--tx, 0), var(--ty, 0)) scale(0);
-    opacity: 0;
+    display: none;
   }
 }
 
 // ==========================================================================
-// THE ALCHEMIST'S OBSERVATORY  (change `home-atelier`)
-// Ambient nebula/stardust canvas + dev-homage HUD + the hidden transmutation.
+// THE TRANSMUTATION CANVASES
+// observatory.js creates two viewport-sized, pointer-transparent, aria-hidden
+// canvases: `--ground` (static dithered prima-materia slab, z 0) and `--dust`
+// (the trailed particle transmutation, z 1). Both fixed so their drawing
+// buffers match the viewport 1:1, both below the circle-less hero content (z 3)
+// and HUD (z 10).
 // ==========================================================================
-
-// The living sky. observatory.js sizes the drawing buffer to the VIEWPORT, so
-// the element is `position: fixed` (a 1:1 match, no CSS scaling) and
-// pointer-events:none so it never intercepts a hero click (AC-A05). z-index 1
-// sits it above the base gradient and below the circle (2) and content (3).
 .observatory {
   position: fixed;
   inset: 0;
   width: 100%;
   height: 100%;
-  z-index: 1;
   pointer-events: none;
-  // The stars "come out": opacity is vestibular-safe for everyone (Val Head),
-  // so this gentle fade-in is allowed even without a motion preference. Made
-  // instant under `reduce` below, honoring no-motion-first.
-  opacity: 0;
-  transition: opacity 1.2s ease;
+  opacity: 0;                       // fades in once lit by JS (opacity = safe)
+  transition: opacity 1s ease;
 
-  &.is-lit {
-    opacity: 1;
-  }
+  &.is-lit { opacity: 1; }
+
+  &--ground { z-index: 0; }
+  &--dust { z-index: 1; }
 }
 
-// Dev-homage HUD: the FPS readout + the motion pause/play control. The pause
-// control is the WCAG 2.2.2 mechanism (research-ui-a11y.md §3.2) that lets a
-// continuously-drifting, auto-started, parallel-to-content starfield be
-// legal -- honoring prefers-reduced-motion alone does NOT discharge 2.2.2.
-// Top-right corner: the sigil-nav owns top-left, the trademark bottom-right.
+// ==========================================================================
+// DEV-HOMAGE HUD — FPS readout + the WCAG 2.2.2 motion pause control.
+// The pause control is the required 2.2.2 mechanism: the resting figure's
+// opacity breath is continuous auto-motion, and prefers-reduced-motion alone
+// does NOT discharge 2.2.2 (research-hero-backgrounds.md §5). Top-right —
+// sigil-nav owns top-left, trademark bottom-right.
+// ==========================================================================
 .observatory-hud {
   position: fixed;
   top: 1.5rem;
@@ -598,16 +180,12 @@ html, body {
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  // System monospace only -- no new self-hosted-font request (preserves the
-  // self-host / cookie-free invariant).
   font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
   opacity: 0.7;
   transition: opacity 0.3s ease;
 
   &:hover,
-  &:focus-within {
-    opacity: 1;
-  }
+  &:focus-within { opacity: 1; }
 
   @include max-width('sm') {
     top: 1rem;
@@ -625,7 +203,7 @@ html, body {
   border-radius: 50%;
   border: 1px solid rgba(205, 180, 219, 0.6);
   background: rgba(33, 28, 48, 0.55);
-  color: #e7dcf1; // icon color -- light lavender, high contrast on the dark disk
+  color: #e7dcf1;
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 
@@ -641,8 +219,8 @@ html, body {
   }
 }
 
-// Icon: two bars while the sky is PLAYING (click => pause). The `.is-paused`
-// state on the HUD swaps it for a play triangle (click => play).
+// Icon: two bars while transmuting (click => pause); `.is-paused` swaps to a
+// play triangle (click => resume).
 .observatory-hud__icon {
   position: relative;
   display: inline-block;
@@ -677,33 +255,30 @@ html, body {
     border-radius: 0;
   }
 
-  &::after {
-    display: none;
-  }
+  &::after { display: none; }
 }
 
 .observatory-hud__fps {
   font-size: 0.72rem;
   letter-spacing: 0.04em;
-  color: #c7d2ea; // decorative (aria-hidden); light blue clears AA regardless
+  color: #c7d2ea;
   font-variant-numeric: tabular-nums;
-  min-width: 4.4em; // reserve space so the changing number never shifts layout
+  min-width: 4.4em;
   user-select: none;
 
-  // On the smallest screens keep only the pause control (the 2.2.2 mechanism);
-  // the FPS number is pure decoration and can go.
-  @include max-width('xs') {
-    display: none;
-  }
+  @include max-width('xs') { display: none; }
 }
 
-// The Great Work reveal -- the motto surfaces in the core of the circle when
-// the hidden spell (Konami) is cast (home.js). Its own dark backing guarantees
-// contrast no matter which star or orb sits behind it. One-shot, user-invoked.
+// ==========================================================================
+// THE GREAT WORK reveal — the motto surfaces over the figure when the hidden
+// spell (Konami) is cast (home.js). Its own dark backing guarantees contrast
+// over any dust/glow behind it. One-shot, user-invoked. Positioned on the
+// figure (left-of-centre desktop, upper-centre mobile).
+// ==========================================================================
 .transmutation-reveal {
   position: absolute;
-  top: 50%;
-  left: 50%;
+  left: 31%;
+  top: 52%;
   transform: translate(-50%, -50%) scale(0.9);
   z-index: 6;
   display: flex;
@@ -715,14 +290,19 @@ html, body {
   opacity: 0;
   transition: opacity 0.5s ease, transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
 
+  @include max-width('lg') {
+    left: 50%;
+    top: 26%;
+  }
+
   &::before {
     content: '';
     position: absolute;
-    inset: -55% -70%;
+    inset: -60% -75%;
     z-index: -1;
     border-radius: 50%;
     background: radial-gradient(ellipse at center,
-      rgba(20, 16, 30, 0.82) 0%,
+      rgba(20, 16, 30, 0.85) 0%,
       rgba(20, 16, 30, 0.55) 45%,
       transparent 75%);
   }
@@ -739,7 +319,7 @@ html, body {
 // _data/palette-manifest.yml -- both are light-on-dark, measured passing).
 .transmutation-reveal__motto {
   font-family: 'Nothing You Could Do', cursive;
-  font-size: 1.9rem;
+  font-size: 2rem;
   line-height: 1.1;
   color: var(--ff-gold); // 7.75:1 / 6.38:1 vs hero-gradient stops (light-on-dark)
   text-shadow: 0 0 18px rgba(230, 165, 83, 0.7), 0 2px 4px rgba(0, 0, 0, 0.45);
@@ -753,7 +333,7 @@ html, body {
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
 }
 
-// The sky flares gold (rubedo) at the instant of transmutation. Triggered ONLY
+// The sky flares gold (rubedo) at the instant of the grand work. Triggered ONLY
 // by the hidden spell -- it never auto-starts, so 2.2.2 does not apply -- and
 // finite (<= 2.6s). z-index 4 washes briefly over the whole hero.
 .alchemist-hero.is-transmuting::after {
@@ -762,7 +342,7 @@ html, body {
   inset: 0;
   z-index: 4;
   pointer-events: none;
-  background: radial-gradient(circle at 50% 45%,
+  background: radial-gradient(circle at 31% 50%,
     rgba(230, 165, 83, 0.30) 0%,
     rgba(230, 165, 83, 0.06) 35%,
     transparent 65%);
@@ -775,21 +355,18 @@ html, body {
   100% { opacity: 0; }
 }
 
-// Reduced-motion: substitute, don't delete (research-ui-a11y.md §3.3). The sky
-// appears instantly, the reveal cross-fades without the scale, and the flare
-// becomes a steady soft wash (opacity only) for the life of the spell.
+// Reduced-motion: substitute, don't delete (research §3.3 / §5). The canvases
+// appear instantly (observatory.js already paints the coagulated figure as a
+// static still), the reveal cross-fades without the scale, and the grand-work
+// flare becomes a steady soft wash for the life of the spell.
 @media (prefers-reduced-motion: reduce) {
-  .observatory {
-    transition: none;
-  }
+  .observatory { transition: none; }
 
   .transmutation-reveal {
     transition: opacity 0.4s ease;
     transform: translate(-50%, -50%);
 
-    &.is-visible {
-      transform: translate(-50%, -50%);
-    }
+    &.is-visible { transform: translate(-50%, -50%); }
   }
 
   .alchemist-hero.is-transmuting::after {

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -557,3 +557,243 @@ html, body {
     opacity: 0;
   }
 }
+
+// ==========================================================================
+// THE ALCHEMIST'S OBSERVATORY  (change `home-atelier`)
+// Ambient nebula/stardust canvas + dev-homage HUD + the hidden transmutation.
+// ==========================================================================
+
+// The living sky. observatory.js sizes the drawing buffer to the VIEWPORT, so
+// the element is `position: fixed` (a 1:1 match, no CSS scaling) and
+// pointer-events:none so it never intercepts a hero click (AC-A05). z-index 1
+// sits it above the base gradient and below the circle (2) and content (3).
+.observatory {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  pointer-events: none;
+  // The stars "come out": opacity is vestibular-safe for everyone (Val Head),
+  // so this gentle fade-in is allowed even without a motion preference. Made
+  // instant under `reduce` below, honoring no-motion-first.
+  opacity: 0;
+  transition: opacity 1.2s ease;
+
+  &.is-lit {
+    opacity: 1;
+  }
+}
+
+// Dev-homage HUD: the FPS readout + the motion pause/play control. The pause
+// control is the WCAG 2.2.2 mechanism (research-ui-a11y.md §3.2) that lets a
+// continuously-drifting, auto-started, parallel-to-content starfield be
+// legal -- honoring prefers-reduced-motion alone does NOT discharge 2.2.2.
+// Top-right corner: the sigil-nav owns top-left, the trademark bottom-right.
+.observatory-hud {
+  position: fixed;
+  top: 1.5rem;
+  right: 1.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  // System monospace only -- no new self-hosted-font request (preserves the
+  // self-host / cookie-free invariant).
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+
+  &:hover,
+  &:focus-within {
+    opacity: 1;
+  }
+
+  @include max-width('sm') {
+    top: 1rem;
+    right: 1rem;
+  }
+}
+
+.observatory-hud__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(205, 180, 219, 0.6);
+  background: rgba(33, 28, 48, 0.55);
+  color: #e7dcf1; // icon color -- light lavender, high contrast on the dark disk
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    background: rgba(49, 42, 69, 0.85);
+    border-color: rgba(205, 180, 219, 0.95);
+    transform: scale(1.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--ff-gold);
+    outline-offset: 3px;
+  }
+}
+
+// Icon: two bars while the sky is PLAYING (click => pause). The `.is-paused`
+// state on the HUD swaps it for a play triangle (click => play).
+.observatory-hud__icon {
+  position: relative;
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  color: inherit;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    width: 3px;
+    height: 12px;
+    background: currentColor;
+    border-radius: 1px;
+  }
+
+  &::before { left: 1px; }
+  &::after { right: 1px; }
+}
+
+.observatory-hud.is-paused .observatory-hud__icon {
+  &::before {
+    left: 2px;
+    width: 0;
+    height: 0;
+    background: transparent;
+    border-style: solid;
+    border-width: 6px 0 6px 10px;
+    border-color: transparent transparent transparent currentColor;
+    border-radius: 0;
+  }
+
+  &::after {
+    display: none;
+  }
+}
+
+.observatory-hud__fps {
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: #c7d2ea; // decorative (aria-hidden); light blue clears AA regardless
+  font-variant-numeric: tabular-nums;
+  min-width: 4.4em; // reserve space so the changing number never shifts layout
+  user-select: none;
+
+  // On the smallest screens keep only the pause control (the 2.2.2 mechanism);
+  // the FPS number is pure decoration and can go.
+  @include max-width('xs') {
+    display: none;
+  }
+}
+
+// The Great Work reveal -- the motto surfaces in the core of the circle when
+// the hidden spell (Konami) is cast (home.js). Its own dark backing guarantees
+// contrast no matter which star or orb sits behind it. One-shot, user-invoked.
+.transmutation-reveal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.9);
+  z-index: 6;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  text-align: center;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease, transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: -55% -70%;
+    z-index: -1;
+    border-radius: 50%;
+    background: radial-gradient(ellipse at center,
+      rgba(20, 16, 30, 0.82) 0%,
+      rgba(20, 16, 30, 0.55) 45%,
+      transparent 75%);
+  }
+
+  &.is-visible {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+// Flat BEM leaves (like .hero__title / .hero__content): the color-bearing
+// elements are top-level selectors so the palette scanner attributes the usage
+// to `.transmutation-reveal__motto` / `__sub` directly (see usage_exemptions in
+// _data/palette-manifest.yml -- both are light-on-dark, measured passing).
+.transmutation-reveal__motto {
+  font-family: 'Nothing You Could Do', cursive;
+  font-size: 1.9rem;
+  line-height: 1.1;
+  color: var(--ff-gold); // 7.75:1 / 6.38:1 vs hero-gradient stops (light-on-dark)
+  text-shadow: 0 0 18px rgba(230, 165, 83, 0.7), 0 2px 4px rgba(0, 0, 0, 0.45);
+  white-space: nowrap;
+}
+
+.transmutation-reveal__sub {
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  color: $background-cream; // 15.18:1 / 12.49:1 vs hero-gradient stops
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
+}
+
+// The sky flares gold (rubedo) at the instant of transmutation. Triggered ONLY
+// by the hidden spell -- it never auto-starts, so 2.2.2 does not apply -- and
+// finite (<= 2.6s). z-index 4 washes briefly over the whole hero.
+.alchemist-hero.is-transmuting::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 45%,
+    rgba(230, 165, 83, 0.30) 0%,
+    rgba(230, 165, 83, 0.06) 35%,
+    transparent 65%);
+  animation: transmute-flare 2.6s ease-out 1 forwards;
+}
+
+@keyframes transmute-flare {
+  0% { opacity: 0; }
+  18% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+// Reduced-motion: substitute, don't delete (research-ui-a11y.md §3.3). The sky
+// appears instantly, the reveal cross-fades without the scale, and the flare
+// becomes a steady soft wash (opacity only) for the life of the spell.
+@media (prefers-reduced-motion: reduce) {
+  .observatory {
+    transition: none;
+  }
+
+  .transmutation-reveal {
+    transition: opacity 0.4s ease;
+    transform: translate(-50%, -50%);
+
+    &.is-visible {
+      transform: translate(-50%, -50%);
+    }
+  }
+
+  .alchemist-hero.is-transmuting::after {
+    animation: none;
+    opacity: 0.5;
+  }
+}

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -1,351 +1,53 @@
-document.addEventListener('DOMContentLoaded', function() {
-  const alchemyCircle = document.querySelector('.alchemy-circle');
-  const symbols = document.querySelectorAll('.alchemy-symbol, .rune');
-  let isDragging = false;
-  let startX, startY, startRotate = 0;
-  let isMobile = window.innerWidth < 768;
+/*
+ * home.js — the homepage's one page-specific easter egg.
+ * ---------------------------------------------------------------------------
+ * The hero visuals now live entirely in observatory.js (the Solve et Coagula
+ * transmutation). All this file does is wire the hidden Konami spell to a
+ * "grand work": it asks the Observatory to flare gold and return the dust to
+ * the alchemy circle, and reveals the motto. Purely a flourish — it changes no
+ * navigation and no content state (AC-A07). Motion is gated behind
+ * no-preference; a reduced-motion visitor gets a calm opacity reveal only.
+ * The console greeting (observatory.js) is what points a curious dev here.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+  var hero = document.querySelector('.alchemist-hero');
+  if (!hero) return;
 
-  // Detect device type and update interactions accordingly
-  function updateDeviceType() {
-    isMobile = window.innerWidth < 768;
+  var SPELL = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+               'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+  var progress = 0;
+  var sealed = false;
 
-    // Adjust animation speed and behavior based on device
-    updateAnimations();
-  }
-
-  function updateAnimations() {
-    // AC-024: no script-created animated node under a reduced-motion preference.
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return;
-    }
-
-    // Apply animations with more subtle effects on mobile
-    // AC-031: finite (2 bob cycles, then hold), not an infinite loop -- the
-    // alchemy-symbol/rune glyphs auto-start on page load in parallel with
-    // the hero name/subtitle/tagline, so WCAG 2.2.2 binds them the same way
-    // it binds the ring rotation below. Delay is capped (not unbounded by
-    // index) so delay + duration * iterations stays <= 5s.
-    symbolNames.forEach((name, index) => {
-      // Find the element
-      let selector = `.alchemy-symbol--${name}, .rune--${name}`;
-      let element = document.querySelector(selector);
-
-      if (element) {
-        // Set unique animation delays to stagger movement
-        const delay = Math.min(index * 0.2, 1); // Stagger, capped at 1s
-        const duration = isMobile ? 1.6 : 1.6 + (index % 2) * 0.3; // 1.6-1.9s
-
-        // Apply the animation style directly -- 2 iterations (one full bob,
-        // there-and-back) then stop; delay(<=1) + duration*2(<=3.8) <= 4.8s.
-        element.style.animation = `float-glyphs ${duration}s ease-in-out ${delay}s 2`;
-      }
-    });
-  }
-
-  // Update on resize with debouncing
-  let resizeTimer;
-  window.addEventListener('resize', function() {
-    clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(updateDeviceType, 250);
-  });
-
-  // Set unique animation delays for each symbol
-  const symbolNames = [
-    'fire', 'water', 'air', 'earth', 'quintessence',
-    'ansuz', 'kenaz', 'raidho', 'laguz'
-  ];
-
-  // Initialize animations
-  updateDeviceType();
-
-  // Make symbols interactive - more touch-friendly on mobile
-  symbols.forEach(symbol => {
-    // Combined event listener for both mouse and touch
-    symbol.addEventListener('mouseenter', handleSymbolHover);
-    symbol.addEventListener('touchstart', handleSymbolTouch, { passive: false });
-    symbol.addEventListener('mouseleave', handleSymbolUnhover);
-
-    // Click/tap handler
-    symbol.addEventListener('click', handleSymbolActivation);
-    symbol.addEventListener('touchend', function(e) {
-      // Prevent default to avoid double-triggering
-      if (e.cancelable) {
-        e.preventDefault();
-      }
-      handleSymbolActivation(e);
-    });
-  });
-
-  function handleSymbolHover() {
-    this.classList.add('hovered');
-  }
-
-  function handleSymbolTouch(e) {
-    // Prevent scrolling when touching symbols
-    if (e.cancelable) {
-      e.preventDefault();
-    }
-
-    // Remove hover from all other symbols first
-    symbols.forEach(s => s.classList.remove('hovered'));
-
-    // Add hover to this symbol
-    this.classList.add('hovered');
-  }
-
-  function handleSymbolUnhover() {
-    this.classList.remove('hovered');
-  }
-
-  function handleSymbolActivation(e) {
-    e.stopPropagation();
-
-    // Add activation effect
-    this.classList.add('activated');
-    setTimeout(() => {
-      this.classList.remove('activated');
-    }, 1000);
-
-    // Show ripple effect
-    createRippleEffect(e);
-
-    // Create particles
-    createParticleEffect(e);
-  }
-
-  function createParticleEffect(e) {
-    const symbol = e.currentTarget;
-    const rect = symbol.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    // Create 8 particles in a circular pattern
-    for (let i = 0; i < 8; i++) {
-      const angle = (i / 8) * Math.PI * 2;
-      const distance = 50;
-      const tx = Math.cos(angle) * distance;
-      const ty = Math.sin(angle) * distance;
-
-      const particle = document.createElement('div');
-      particle.className = 'alchemy-particle';
-      particle.style.setProperty('--tx', `${tx}px`);
-      particle.style.setProperty('--ty', `${ty}px`);
-      particle.style.left = `${centerX}px`;
-      particle.style.top = `${centerY}px`;
-
-      document.body.appendChild(particle);
-
-      // Remove particle after animation
-      setTimeout(() => {
-        particle.remove();
-      }, 1000);
-    }
-  }
-
-  function createRippleEffect(e) {
-    const ripple = document.createElement('div');
-    ripple.className = 'alchemy-ripple';
-
-    // Position differently based on event type
-    if (e.type === 'touchend' && e.changedTouches) {
-      ripple.style.left = e.changedTouches[0].clientX + 'px';
-      ripple.style.top = e.changedTouches[0].clientY + 'px';
+  document.addEventListener('keydown', function (e) {
+    var key = e.key && e.key.length === 1 ? e.key.toLowerCase() : e.key;
+    if (key === SPELL[progress]) {
+      progress++;
+      if (progress === SPELL.length) { progress = 0; cast(); }
     } else {
-      ripple.style.left = e.clientX + 'px';
-      ripple.style.top = e.clientY + 'px';
-    }
-
-    document.body.appendChild(ripple);
-
-    // Remove ripple after animation
-    setTimeout(() => {
-      ripple.remove();
-    }, 1000);
-  }
-
-  // Make circle draggable/rotatable - support both mouse and touch
-  alchemyCircle.addEventListener('mousedown', handleCircleGrabStart);
-  alchemyCircle.addEventListener('touchstart', handleCircleTouchStart, { passive: false });
-
-  document.addEventListener('mousemove', handleCircleMove);
-  document.addEventListener('touchmove', handleCircleTouchMove, { passive: false });
-
-  document.addEventListener('mouseup', handleCircleRelease);
-  document.addEventListener('touchend', handleCircleRelease);
-  document.addEventListener('touchcancel', handleCircleRelease);
-
-  function handleCircleGrabStart(e) {
-    startDrag(e.clientX, e.clientY);
-    e.preventDefault();
-  }
-
-  function handleCircleTouchStart(e) {
-    if (e.touches.length === 1) {
-      startDrag(e.touches[0].clientX, e.touches[0].clientY);
-      if (e.cancelable) {
-        e.preventDefault(); // Prevent scrolling while rotating
-      }
-    }
-  }
-
-  function startDrag(x, y) {
-    isDragging = true;
-    startX = x;
-    startY = y;
-    alchemyCircle.classList.add('interacting');
-
-    // Get current rotation
-    const style = window.getComputedStyle(alchemyCircle);
-    const transform = style.getPropertyValue('transform');
-    if (transform !== 'none') {
-      const values = transform.split('(')[1].split(')')[0].split(',');
-      const a = values[0];
-      const b = values[1];
-      startRotate = Math.round(Math.atan2(parseFloat(b), parseFloat(a)) * (180/Math.PI));
-    } else {
-      startRotate = 0;
-    }
-  }
-
-  function handleCircleMove(e) {
-    if (!isDragging) return;
-    moveCircle(e.clientX, e.clientY);
-  }
-
-  function handleCircleTouchMove(e) {
-    if (!isDragging || e.touches.length !== 1) return;
-    moveCircle(e.touches[0].clientX, e.touches[0].clientY);
-    if (e.cancelable) {
-      e.preventDefault(); // Prevent scrolling while rotating
-    }
-  }
-
-  function moveCircle(x, y) {
-    const rect = alchemyCircle.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    const startAngle = Math.atan2(startY - centerY, startX - centerX);
-    const currentAngle = Math.atan2(y - centerY, x - centerX);
-
-    const rotation = (currentAngle - startAngle) * (180 / Math.PI);
-
-    alchemyCircle.style.transform = `rotate(${startRotate + rotation}deg)`;
-  }
-
-  function handleCircleRelease() {
-    isDragging = false;
-    alchemyCircle.classList.remove('interacting');
-  }
-
-  // Add glow effect on hover/touch
-  alchemyCircle.addEventListener('mousemove', handleCircleGlow);
-  alchemyCircle.addEventListener('touchmove', function(e) {
-    if (e.touches.length === 1 && !isDragging) {
-      const touch = e.touches[0];
-      handleCircleGlow({
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        target: alchemyCircle
-      });
+      progress = (key === SPELL[0]) ? 1 : 0;
     }
   });
 
-  function handleCircleGlow(e) {
-    if (isDragging) return;
+  function cast() {
+    if (sealed) return;
+    sealed = true;
+    var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    const rect = alchemyCircle.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    document.documentElement.style.setProperty('--glow-x', `${x}px`);
-    document.documentElement.style.setProperty('--glow-y', `${y}px`);
-    document.documentElement.style.setProperty('--glow-strength', '1');
-  }
-
-  alchemyCircle.addEventListener('mouseleave', function() {
-    document.documentElement.style.setProperty('--glow-strength', '0');
-  });
-
-  // Remove glow on touch end
-  alchemyCircle.addEventListener('touchend', function() {
-    document.documentElement.style.setProperty('--glow-strength', '0');
-  });
-
-  // Responsive adjustments for orientation changes
-  window.addEventListener('orientationchange', function() {
-    // Brief timeout to allow DOM to update before recalculating
-    setTimeout(function() {
-      updateDeviceType();
-
-      // Reset any transformations to avoid strange positioning
-      alchemyCircle.style.transform = 'rotate(0deg)';
-    }, 200);
-  });
-
-  // -------------------------------------------------------------------------
-  // The Great Work -- a hidden transmutation for those who know the old spell.
-  // Konami code (↑ ↑ ↓ ↓ ← → ← → B A). Purely a flourish: it changes no
-  // navigation and no content state (AC-A07). Motion is gated behind
-  // no-preference; a reduced-motion visitor gets a calm opacity reveal of the
-  // motto instead of the sigil cascade. The console greeting (observatory.js)
-  // is what points a curious dev at this spell.
-  // -------------------------------------------------------------------------
-  (function initTransmutation() {
-    const SPELL = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
-                   'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
-    let progress = 0;
-    let sealed = false; // debounce while a transmutation is already playing
-
-    document.addEventListener('keydown', function (e) {
-      const key = e.key && e.key.length === 1 ? e.key.toLowerCase() : e.key;
-      if (key === SPELL[progress]) {
-        progress++;
-        if (progress === SPELL.length) {
-          progress = 0;
-          castTransmutation();
-        }
-      } else {
-        // A wrong key that is itself the opening note restarts cleanly.
-        progress = (key === SPELL[0]) ? 1 : 0;
-      }
-    });
-
-    function castTransmutation() {
-      if (sealed) return;
-      sealed = true;
-      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-      // Ask the sky to flare (no-op if observatory.js didn't load).
-      if (window.Observatory && typeof window.Observatory.flare === 'function') {
-        window.Observatory.flare();
-      }
-
-      // Light every element sigil in sequence -- reuse the existing activated
-      // look. Skipped under reduced motion (the reveal below is enough).
-      if (!reduce) {
-        symbols.forEach((sym, i) => {
-          setTimeout(() => {
-            sym.classList.add('activated');
-            setTimeout(() => sym.classList.remove('activated'), 900);
-          }, i * 90);
-        });
-      }
-
-      // Reveal the motto in the core of the circle.
-      const reveal = document.createElement('div');
-      reveal.className = 'transmutation-reveal';
-      reveal.setAttribute('role', 'status');
-      reveal.innerHTML =
-        '<span class="transmutation-reveal__motto">Solve et Coagula</span>' +
-        '<span class="transmutation-reveal__sub">— dissolve, and bind anew —</span>';
-      (alchemyCircle || document.querySelector('.alchemist-hero') || document.body)
-        .appendChild(reveal);
-      requestAnimationFrame(() => reveal.classList.add('is-visible'));
-
-      const life = reduce ? 2200 : 2600;
-      setTimeout(() => reveal.classList.remove('is-visible'), life - 500);
-      setTimeout(() => { reveal.remove(); sealed = false; }, life);
+    if (window.Observatory && typeof window.Observatory.flare === 'function') {
+      window.Observatory.flare();
     }
-  })();
+
+    var reveal = document.createElement('div');
+    reveal.className = 'transmutation-reveal';
+    reveal.setAttribute('role', 'status');
+    reveal.innerHTML =
+      '<span class="transmutation-reveal__motto">Solve et Coagula</span>' +
+      '<span class="transmutation-reveal__sub">— dissolve, and bind anew —</span>';
+    hero.appendChild(reveal);
+    requestAnimationFrame(function () { reveal.classList.add('is-visible'); });
+
+    var life = reduce ? 2200 : 2600;
+    setTimeout(function () { reveal.classList.remove('is-visible'); }, life - 500);
+    setTimeout(function () { reveal.remove(); sealed = false; }, life);
+  }
 });

--- a/assets/js/home.js
+++ b/assets/js/home.js
@@ -282,4 +282,70 @@ document.addEventListener('DOMContentLoaded', function() {
       alchemyCircle.style.transform = 'rotate(0deg)';
     }, 200);
   });
+
+  // -------------------------------------------------------------------------
+  // The Great Work -- a hidden transmutation for those who know the old spell.
+  // Konami code (↑ ↑ ↓ ↓ ← → ← → B A). Purely a flourish: it changes no
+  // navigation and no content state (AC-A07). Motion is gated behind
+  // no-preference; a reduced-motion visitor gets a calm opacity reveal of the
+  // motto instead of the sigil cascade. The console greeting (observatory.js)
+  // is what points a curious dev at this spell.
+  // -------------------------------------------------------------------------
+  (function initTransmutation() {
+    const SPELL = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown',
+                   'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'b', 'a'];
+    let progress = 0;
+    let sealed = false; // debounce while a transmutation is already playing
+
+    document.addEventListener('keydown', function (e) {
+      const key = e.key && e.key.length === 1 ? e.key.toLowerCase() : e.key;
+      if (key === SPELL[progress]) {
+        progress++;
+        if (progress === SPELL.length) {
+          progress = 0;
+          castTransmutation();
+        }
+      } else {
+        // A wrong key that is itself the opening note restarts cleanly.
+        progress = (key === SPELL[0]) ? 1 : 0;
+      }
+    });
+
+    function castTransmutation() {
+      if (sealed) return;
+      sealed = true;
+      const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+      // Ask the sky to flare (no-op if observatory.js didn't load).
+      if (window.Observatory && typeof window.Observatory.flare === 'function') {
+        window.Observatory.flare();
+      }
+
+      // Light every element sigil in sequence -- reuse the existing activated
+      // look. Skipped under reduced motion (the reveal below is enough).
+      if (!reduce) {
+        symbols.forEach((sym, i) => {
+          setTimeout(() => {
+            sym.classList.add('activated');
+            setTimeout(() => sym.classList.remove('activated'), 900);
+          }, i * 90);
+        });
+      }
+
+      // Reveal the motto in the core of the circle.
+      const reveal = document.createElement('div');
+      reveal.className = 'transmutation-reveal';
+      reveal.setAttribute('role', 'status');
+      reveal.innerHTML =
+        '<span class="transmutation-reveal__motto">Solve et Coagula</span>' +
+        '<span class="transmutation-reveal__sub">— dissolve, and bind anew —</span>';
+      (alchemyCircle || document.querySelector('.alchemist-hero') || document.body)
+        .appendChild(reveal);
+      requestAnimationFrame(() => reveal.classList.add('is-visible'));
+
+      const life = reduce ? 2200 : 2600;
+      setTimeout(() => reveal.classList.remove('is-visible'), life - 500);
+      setTimeout(() => { reveal.remove(); sealed = false; }, life);
+    }
+  })();
 });

--- a/assets/js/observatory.js
+++ b/assets/js/observatory.js
@@ -1,0 +1,416 @@
+/*
+ * observatory.js -- "The Alchemist's Observatory"
+ * ---------------------------------------------------------------------------
+ * A first-party, dependency-free canvas that turns the homepage hero into a
+ * living night sky: drifting stardust, soft nebula clouds, and a constellation
+ * that wakes where the pointer travels. Inspired by earendil.com's live-render
+ * ethos (the reason its HUD carries an FPS readout).
+ *
+ * Accessibility contract (see .claude/rebrand/research-ui-a11y.md §3.2, and the
+ * change spec .spectra/changes/home-atelier/spec.md):
+ *
+ *   - No-motion-first (Tatiana Mac): the animation loop starts ONLY when the OS
+ *     expresses no reduced-motion preference AND the visitor has not paused it.
+ *     Otherwise a single static frame is painted -- premium, not blank.
+ *
+ *   - WCAG 2.2.2 (Pause, Stop, Hide): a drifting starfield auto-starts, lasts
+ *     >5s, and sits in parallel with the hero text -- all three conditions hold,
+ *     so honoring prefers-reduced-motion is NOT enough (the single most-believed
+ *     false thing in this area, per the research doc). The HUD's pause/play
+ *     button IS the required mechanism, available to everyone, and it persists.
+ *
+ *   - Substitution over deletion: a reduced-motion visitor may still opt IN via
+ *     the same control -- agency, not a wall.
+ *
+ *   - Pointer reactivity is LOCAL (stars near the cursor drift toward it and
+ *     link up) with only a whisper of whole-scene parallax (<=6px), keeping it
+ *     off the high-risk end of Val Head's vestibular taxonomy.
+ */
+(function () {
+  'use strict';
+
+  var hero = document.querySelector('.alchemist-hero');
+  if (!hero || !window.requestAnimationFrame) return;
+
+  var reduceQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+  var STORE_KEY = 'observatory-motion'; // 'on' | 'off' | null (follow OS)
+
+  // ---- Motion policy ------------------------------------------------------
+  function storedPref() {
+    try { return localStorage.getItem(STORE_KEY); } catch (e) { return null; }
+  }
+  function savePref(v) {
+    try { localStorage.setItem(STORE_KEY, v); } catch (e) { /* private mode: fine */ }
+  }
+  // The effective "should the loop run" decision. Explicit user choice wins;
+  // absent one, we follow the OS (no-motion-first).
+  function motionEnabled() {
+    var pref = storedPref();
+    if (pref === 'off') return false;
+    if (pref === 'on') return true;
+    return !reduceQuery.matches;
+  }
+
+  // ---- Canvas + offscreen nebula ------------------------------------------
+  var canvas = document.createElement('canvas');
+  canvas.className = 'observatory';
+  canvas.setAttribute('aria-hidden', 'true');
+  var ctx = canvas.getContext('2d');
+  hero.insertBefore(canvas, hero.firstChild);
+
+  var nebula = document.createElement('canvas'); // offscreen, pre-rendered once per resize
+  var nctx = nebula.getContext('2d');
+
+  var dpr = Math.min(window.devicePixelRatio || 1, 2);
+  var W = 0, H = 0;                 // CSS pixels
+  var stars = [];
+  var pointer = { x: -9999, y: -9999, active: false };
+  var scene = { px: 0, py: 0 };     // eased parallax offset (<=6px)
+  var rafId = null;
+  var running = false;
+
+  // Palette drawn from _sass/settings/_variables.scss (pastels over the
+  // #211C30 -> #312A45 hero gradient).
+  var STAR_TINTS = [
+    'rgba(248,245,242,',   // cream
+    'rgba(205,180,219,',   // pastel purple
+    'rgba(185,201,230,',   // pastel blue
+    'rgba(230,165,83,',    // ff-gold (sparingly)
+    'rgba(248,209,224,'    // pastel pink
+  ];
+  var NEBULA_BLOBS = [
+    { xr: 0.22, yr: 0.28, col: 'rgba(103,58,183,',  a: 0.16 }, // purple
+    { xr: 0.80, yr: 0.68, col: 'rgba(63,81,181,',   a: 0.14 }, // indigo
+    { xr: 0.62, yr: 0.20, col: 'rgba(248,209,224,', a: 0.07 }, // pink whisper
+    { xr: 0.35, yr: 0.82, col: 'rgba(230,165,83,',  a: 0.05 }  // gold whisper
+  ];
+
+  // Seeded PRNG (mulberry32) so the sky is REPRODUCIBLE: a fixed constellation
+  // every load (which is also how a real night sky behaves), and -- crucially --
+  // a byte-identical static frame for the pixel-diff visual-baseline harness,
+  // which runs under reducedMotion:'reduce' and would otherwise diff a random
+  // starfield on every run.
+  function makeRng(seed) {
+    return function () {
+      seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
+      var t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function starBudget() {
+    // Scale with area, but stay bounded so the loop never pegs the CPU
+    // (AC-A10). ~1 star per 12k CSS px^2, hard-capped.
+    return Math.max(40, Math.min(150, Math.round((W * H) / 12000)));
+  }
+
+  function seedStars() {
+    var rand = makeRng(0x5eed);          // reset each seeding -> stable layout
+    var n = starBudget();
+    stars = [];
+    for (var i = 0; i < n; i++) {
+      stars.push({
+        x: rand() * W,
+        y: rand() * H,
+        z: 0.4 + rand() * 0.9,           // depth: size + parallax weight + speed
+        r: 0.5 + rand() * 1.4,           // radius
+        vx: (rand() - 0.5) * 0.06,       // slow ambient drift (CSS px / frame)
+        vy: (rand() - 0.5) * 0.06,
+        tw: rand() * Math.PI * 2,         // twinkle phase
+        tws: 0.6 + rand() * 1.2,          // twinkle speed
+        base: 0.35 + rand() * 0.5,        // base opacity
+        tint: STAR_TINTS[(rand() * STAR_TINTS.length) | 0]
+      });
+    }
+  }
+
+  function renderNebula() {
+    // Pre-render the soft clouds ONCE per resize into an offscreen buffer with
+    // a margin so the whole-scene parallax never exposes an edge. Each frame
+    // then only blits this (cheap) instead of rebuilding gradients.
+    var margin = 24;
+    nebula.width = (W + margin * 2) * dpr;
+    nebula.height = (H + margin * 2) * dpr;
+    nctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    nctx.clearRect(0, 0, W + margin * 2, H + margin * 2);
+    for (var i = 0; i < NEBULA_BLOBS.length; i++) {
+      var b = NEBULA_BLOBS[i];
+      var cx = margin + b.xr * W;
+      var cy = margin + b.yr * H;
+      var rad = Math.max(W, H) * 0.45;
+      var g = nctx.createRadialGradient(cx, cy, 0, cx, cy, rad);
+      g.addColorStop(0, b.col + b.a + ')');
+      g.addColorStop(1, b.col + '0)');
+      nctx.fillStyle = g;
+      nctx.fillRect(0, 0, W + margin * 2, H + margin * 2);
+    }
+  }
+
+  function resize() {
+    W = window.innerWidth;
+    H = window.innerHeight;
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = W * dpr;
+    canvas.height = H * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    seedStars();
+    renderNebula();
+  }
+
+  // ---- Rendering ----------------------------------------------------------
+  function drawFrame(dt, animate) {
+    ctx.clearRect(0, 0, W, H);
+
+    // Ease the scene parallax toward the pointer (whisper only: <=6px).
+    var targetPx = 0, targetPy = 0;
+    if (pointer.active && animate) {
+      targetPx = ((pointer.x / W) - 0.5) * -12; // opposite the cursor, subtle
+      targetPy = ((pointer.y / H) - 0.5) * -12;
+    }
+    scene.px += (targetPx - scene.px) * 0.06;
+    scene.py += (targetPy - scene.py) * 0.06;
+
+    // Nebula (blitted, parallax-shifted). Margin was 24px; center the buffer.
+    ctx.drawImage(nebula, -24 + scene.px * 0.6, -24 + scene.py * 0.6, W + 48, H + 48);
+
+    // Stars
+    var influence = 150;         // pointer influence radius
+    var linkDist = 116;          // constellation link distance
+    var near = [];               // stars inside the pointer's influence
+    for (var i = 0; i < stars.length; i++) {
+      var s = stars[i];
+      if (animate) {
+        s.x += s.vx * s.z * dt;
+        s.y += s.vy * s.z * dt;
+        s.tw += 0.02 * s.tws * dt;
+        // wrap
+        if (s.x < -4) s.x = W + 4; else if (s.x > W + 4) s.x = -4;
+        if (s.y < -4) s.y = H + 4; else if (s.y > H + 4) s.y = -4;
+      }
+
+      var dx = 0, dy = 0, drawX = s.x + scene.px * s.z, drawY = s.y + scene.py * s.z;
+      var glow = 0;
+      if (pointer.active) {
+        dx = pointer.x - s.x;
+        dy = pointer.y - s.y;
+        var d2 = dx * dx + dy * dy;
+        if (d2 < influence * influence) {
+          var d = Math.sqrt(d2) || 1;
+          var pull = (1 - d / influence);
+          glow = pull;
+          if (animate) {
+            // LOCAL attraction: nudge toward the cursor (short distance, small
+            // area -> low vestibular risk).
+            drawX += (dx / d) * pull * 6;
+            drawY += (dy / d) * pull * 6;
+          } else {
+            drawX += (dx / d) * pull * 6; // static frame still shows the halo shape
+          }
+          near.push({ s: s, x: drawX, y: drawY });
+        }
+      }
+
+      var tw = animate ? (0.72 + 0.28 * Math.sin(s.tw)) : 0.85;
+      var alpha = Math.min(1, s.base * tw + glow * 0.5);
+      ctx.beginPath();
+      ctx.arc(drawX, drawY, s.r + glow * 0.9, 0, Math.PI * 2);
+      ctx.fillStyle = s.tint + alpha.toFixed(3) + ')';
+      ctx.fill();
+    }
+
+    // Constellation: link near-pointer stars to each other, and to the cursor.
+    // Only the small `near` subset is considered, so this stays cheap.
+    if (near.length > 1) {
+      for (var a = 0; a < near.length; a++) {
+        for (var b2 = a + 1; b2 < near.length; b2++) {
+          var lx = near[a].x - near[b2].x, ly = near[a].y - near[b2].y;
+          var ld = Math.sqrt(lx * lx + ly * ly);
+          if (ld < linkDist) {
+            var la = (1 - ld / linkDist) * 0.5;
+            ctx.beginPath();
+            ctx.moveTo(near[a].x, near[a].y);
+            ctx.lineTo(near[b2].x, near[b2].y);
+            ctx.strokeStyle = 'rgba(205,180,219,' + la.toFixed(3) + ')';
+            ctx.lineWidth = 0.6;
+            ctx.stroke();
+          }
+        }
+      }
+    }
+  }
+
+  // ---- Loop + FPS ---------------------------------------------------------
+  var lastTs = 0, frames = 0, fpsAccum = 0, fps = 0;
+
+  function loop(ts) {
+    if (!running) return;
+    var dt = lastTs ? Math.min((ts - lastTs) / 16.667, 3) : 1; // frames elapsed, clamped
+    lastTs = ts;
+
+    drawFrame(dt, true);
+
+    // FPS readout, refreshed ~twice a second.
+    frames++;
+    fpsAccum += ts - (loop._prev || ts);
+    loop._prev = ts;
+    if (fpsAccum >= 500) {
+      fps = Math.round((frames * 1000) / fpsAccum);
+      frames = 0; fpsAccum = 0;
+      setFps(fps);
+    }
+
+    rafId = window.requestAnimationFrame(loop);
+  }
+
+  function start() {
+    if (running) return;
+    running = true;
+    lastTs = 0; loop._prev = 0; frames = 0; fpsAccum = 0;
+    rafId = window.requestAnimationFrame(loop);
+  }
+  function stop() {
+    running = false;
+    if (rafId) { window.cancelAnimationFrame(rafId); rafId = null; }
+    setFps(null);
+  }
+  function staticFrame() {
+    // One premium still frame -- no loop, no motion.
+    drawFrame(1, false);
+    setFps(null);
+  }
+
+  // ---- HUD (FPS readout + the 2.2.2 pause control) ------------------------
+  var hud = document.createElement('div');
+  hud.className = 'observatory-hud';
+
+  var toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'observatory-hud__toggle';
+  var icon = document.createElement('span');
+  icon.className = 'observatory-hud__icon';
+  icon.setAttribute('aria-hidden', 'true');
+  toggle.appendChild(icon);
+
+  var fpsEl = document.createElement('span');
+  fpsEl.className = 'observatory-hud__fps';
+  fpsEl.setAttribute('aria-hidden', 'true');
+  fpsEl.textContent = 'FPS —';
+
+  hud.appendChild(toggle);
+  hud.appendChild(fpsEl);
+  hero.appendChild(hud);
+
+  function setFps(v) {
+    fpsEl.textContent = 'FPS ' + (v == null ? '—' : v);
+  }
+
+  function reflectToggle(on) {
+    // aria-pressed = "is motion paused". on === animating.
+    toggle.setAttribute('aria-pressed', on ? 'false' : 'true');
+    toggle.setAttribute('aria-label', on ? 'Pause ambient motion' : 'Play ambient motion');
+    toggle.title = on ? 'Pause the observatory' : 'Wake the observatory';
+    hud.classList.toggle('is-paused', !on);
+  }
+
+  // Apply the current policy: run the loop or hold a static frame.
+  function apply() {
+    var on = motionEnabled();
+    reflectToggle(on);
+    if (on) start(); else { stop(); staticFrame(); }
+  }
+
+  toggle.addEventListener('click', function () {
+    var on = motionEnabled();
+    savePref(on ? 'off' : 'on'); // explicit choice overrides the OS default
+    apply();
+  });
+
+  // ---- Pointer, resize, visibility ----------------------------------------
+  function onPointer(e) {
+    var t = e.touches ? e.touches[0] : e;
+    if (!t) return;
+    pointer.x = t.clientX;
+    pointer.y = t.clientY;
+    pointer.active = true;
+    // A paused/static observatory still reveals the constellation on hover --
+    // it's pointer-driven (2.3.3), not auto-play, so it stays available even
+    // when the ambient loop is stopped.
+    if (!running) staticFrame();
+  }
+  function clearPointer() {
+    pointer.active = false;
+    if (!running) staticFrame();
+  }
+  window.addEventListener('mousemove', onPointer, { passive: true });
+  window.addEventListener('touchmove', onPointer, { passive: true });
+  window.addEventListener('mouseleave', clearPointer);
+  window.addEventListener('touchend', clearPointer);
+
+  var resizeTimer;
+  window.addEventListener('resize', function () {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function () {
+      resize();
+      if (running) { /* loop keeps going */ } else { staticFrame(); }
+    }, 200);
+  });
+
+  // Never burn cycles on a hidden tab (AC-A10).
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) {
+      if (running) stop();
+    } else {
+      if (motionEnabled()) start();
+    }
+  });
+
+  // React live to an OS reduced-motion change (only matters when the visitor
+  // hasn't made an explicit choice).
+  var onReduceChange = function () { if (storedPref() == null) apply(); };
+  if (reduceQuery.addEventListener) reduceQuery.addEventListener('change', onReduceChange);
+  else if (reduceQuery.addListener) reduceQuery.addListener(onReduceChange);
+
+  // ---- Console homage (earendil-style dev wink) ---------------------------
+  function consoleSigil() {
+    var sigil = [
+      '',
+      '        .  *  .   ·   *   .  ·  *  .',
+      '     ·   ╭─────────────────────╮   *',
+      '   *     │   ☿   THE  ATELIER   │  ·',
+      '     .   │   ⚗   OBSERVATORY    │    .',
+      '   ·     ╰─────────────────────╯  *  .',
+      '        *   .   ·    *   .   ·   *',
+      ''
+    ].join('\n');
+    try {
+      console.log('%c' + sigil, 'color:#cdb4db; font-family:monospace; line-height:1.15;');
+      console.log(
+        '%cSolve et Coagula.%c  You found the console — a true alchemist always looks beneath the surface.\n' +
+        'The stars remember those who look up. Some old spells still work on keyboards: %c↑ ↑ ↓ ↓ ← → ← → B A%c',
+        'color:#e6a553; font-weight:bold; font-family:monospace;',
+        'color:#b9c9e6; font-family:monospace;',
+        'color:#f8d1e0; font-family:monospace;',
+        'color:#b9c9e6; font-family:monospace;'
+      );
+    } catch (e) { /* no console: fine */ }
+  }
+
+  // ---- Boot ---------------------------------------------------------------
+  resize();
+  // Fade the sky in (opacity is vestibular-safe for everyone).
+  requestAnimationFrame(function () { canvas.classList.add('is-lit'); });
+  apply();
+  consoleSigil();
+
+  // Expose a tiny hook so home.js's Konami payoff can ask the sky to flare
+  // without either file reaching into the other's internals.
+  window.Observatory = {
+    flare: function () {
+      if (!hero) return;
+      hero.classList.add('is-transmuting');
+      window.setTimeout(function () { hero.classList.remove('is-transmuting'); }, 2600);
+    },
+    isRunning: function () { return running; }
+  };
+})();

--- a/assets/js/observatory.js
+++ b/assets/js/observatory.js
@@ -1,30 +1,31 @@
 /*
- * observatory.js -- "The Alchemist's Observatory"
+ * observatory.js — "Solve et Coagula" (the Alchemist's Observatory, rework)
  * ---------------------------------------------------------------------------
- * A first-party, dependency-free canvas that turns the homepage hero into a
- * living night sky: drifting stardust, soft nebula clouds, and a constellation
- * that wakes where the pointer travels. Inspired by earendil.com's live-render
- * ethos (the reason its HUD carries an FPS readout).
+ * The hero background enacts the motto. A few thousand motes of prima materia
+ * endlessly cycle between two states:
+ *   · SOLVE   — the assembled figure DISSOLVES into divergence-free curl-noise
+ *               turbulence (matter unbound);
+ *   · COAGULA — the cloud CONDENSES onto an alchemical figure sampled from the
+ *               site's own sigil geometry (matter re-formed).
+ * The dust is grounded on a static slab of dithered "prima materia" (nigredo
+ * violet shot with rare gold veins, quantised through a Bayer-8 matrix for a
+ * 16-bit-era grain). This deliberately replaces the old starfield + constellation
+ * (proximity lines are the canvas-tutorial cliché — deleted at the root).
  *
- * Accessibility contract (see .claude/rebrand/research-ui-a11y.md §3.2, and the
- * change spec .spectra/changes/home-atelier/spec.md):
+ * First-party only (vanilla Canvas 2D, hand-rolled value/curl noise — no libs).
+ * Research basis + citations: .claude/rebrand/research-hero-backgrounds.md
+ * (Concept A over Concept B).
  *
- *   - No-motion-first (Tatiana Mac): the animation loop starts ONLY when the OS
- *     expresses no reduced-motion preference AND the visitor has not paused it.
- *     Otherwise a single static frame is painted -- premium, not blank.
- *
- *   - WCAG 2.2.2 (Pause, Stop, Hide): a drifting starfield auto-starts, lasts
- *     >5s, and sits in parallel with the hero text -- all three conditions hold,
- *     so honoring prefers-reduced-motion is NOT enough (the single most-believed
- *     false thing in this area, per the research doc). The HUD's pause/play
- *     button IS the required mechanism, available to everyone, and it persists.
- *
- *   - Substitution over deletion: a reduced-motion visitor may still opt IN via
- *     the same control -- agency, not a wall.
- *
- *   - Pointer reactivity is LOCAL (stars near the cursor drift toward it and
- *     link up) with only a whisper of whole-scene parallax (<=6px), keeping it
- *     off the high-risk end of Val Head's vestibular taxonomy.
+ * Accessibility (research §5/§6, and .claude/rebrand/research-ui-a11y.md §3.2):
+ *   · No-motion-first: the rAF loop starts ONLY under
+ *     prefers-reduced-motion:no-preference and when not paused. Otherwise a
+ *     premium STILL of the coagulated figure is drawn — never a blank.
+ *   · WCAG 2.2.2: load runs ONE condense (≤ ~3.5s) then the figure rests with a
+ *     faint opacity breath. Because the breath is continuous, the HUD pause/play
+ *     button is the required 2.2.2 mechanism (prefers-reduced-motion alone does
+ *     NOT discharge 2.2.2). Pointer/click motion is user-initiated (2.3.3) and
+ *     decays well under 5s.
+ *   · Pointer response is MATERIAL (dust scatters/stirs), not diagrammatic.
  */
 (function () {
   'use strict';
@@ -35,382 +36,452 @@
   var reduceQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
   var STORE_KEY = 'observatory-motion'; // 'on' | 'off' | null (follow OS)
 
-  // ---- Motion policy ------------------------------------------------------
-  function storedPref() {
-    try { return localStorage.getItem(STORE_KEY); } catch (e) { return null; }
-  }
-  function savePref(v) {
-    try { localStorage.setItem(STORE_KEY, v); } catch (e) { /* private mode: fine */ }
-  }
-  // The effective "should the loop run" decision. Explicit user choice wins;
-  // absent one, we follow the OS (no-motion-first).
+  function storedPref() { try { return localStorage.getItem(STORE_KEY); } catch (e) { return null; } }
+  function savePref(v) { try { localStorage.setItem(STORE_KEY, v); } catch (e) {} }
   function motionEnabled() {
-    var pref = storedPref();
-    if (pref === 'off') return false;
-    if (pref === 'on') return true;
+    var p = storedPref();
+    if (p === 'off') return false;
+    if (p === 'on') return true;
     return !reduceQuery.matches;
   }
 
-  // ---- Canvas + offscreen nebula ------------------------------------------
-  var canvas = document.createElement('canvas');
-  canvas.className = 'observatory';
-  canvas.setAttribute('aria-hidden', 'true');
-  var ctx = canvas.getContext('2d');
-  hero.insertBefore(canvas, hero.firstChild);
+  // ---- Palette (from _sass/settings/_variables.scss) -----------------------
+  var NIGREDO = [33, 28, 48];    // #211C30
+  var VIOLET = [49, 42, 69];     // #312A45
+  var AURUM = [230, 165, 83];    // #e6a553  (gold)
+  var LAVENDER = [177, 156, 217]; // #b19cd9  (dissolved dust tint)
 
-  var nebula = document.createElement('canvas'); // offscreen, pre-rendered once per resize
-  var nctx = nebula.getContext('2d');
+  // ---- Canvases: static dithered ground + trailed particle layer -----------
+  var bg = document.createElement('canvas');
+  bg.className = 'observatory observatory--ground';
+  bg.setAttribute('aria-hidden', 'true');
+  var bctx = bg.getContext('2d');
 
-  var dpr = Math.min(window.devicePixelRatio || 1, 2);
-  var W = 0, H = 0;                 // CSS pixels
-  var stars = [];
-  var pointer = { x: -9999, y: -9999, active: false };
-  var scene = { px: 0, py: 0 };     // eased parallax offset (<=6px)
-  var rafId = null;
-  var running = false;
+  var fg = document.createElement('canvas');
+  fg.className = 'observatory observatory--dust';
+  fg.setAttribute('aria-hidden', 'true');
+  var fctx = fg.getContext('2d');
 
-  // Palette drawn from _sass/settings/_variables.scss (pastels over the
-  // #211C30 -> #312A45 hero gradient).
-  var STAR_TINTS = [
-    'rgba(248,245,242,',   // cream
-    'rgba(205,180,219,',   // pastel purple
-    'rgba(185,201,230,',   // pastel blue
-    'rgba(230,165,83,',    // ff-gold (sparingly)
-    'rgba(248,209,224,'    // pastel pink
-  ];
-  var NEBULA_BLOBS = [
-    { xr: 0.22, yr: 0.28, col: 'rgba(103,58,183,',  a: 0.16 }, // purple
-    { xr: 0.80, yr: 0.68, col: 'rgba(63,81,181,',   a: 0.14 }, // indigo
-    { xr: 0.62, yr: 0.20, col: 'rgba(248,209,224,', a: 0.07 }, // pink whisper
-    { xr: 0.35, yr: 0.82, col: 'rgba(230,165,83,',  a: 0.05 }  // gold whisper
-  ];
+  hero.insertBefore(fg, hero.firstChild);
+  hero.insertBefore(bg, hero.firstChild);
 
-  // Seeded PRNG (mulberry32) so the sky is REPRODUCIBLE: a fixed constellation
-  // every load (which is also how a real night sky behaves), and -- crucially --
-  // a byte-identical static frame for the pixel-diff visual-baseline harness,
-  // which runs under reducedMotion:'reduce' and would otherwise diff a random
-  // starfield on every run.
-  function makeRng(seed) {
-    return function () {
-      seed |= 0; seed = (seed + 0x6d2b79f5) | 0;
-      var t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
-      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-    };
+  var dpr = 1, W = 0, H = 0;
+  var figureCX = 0, figureCY = 0, figureSize = 0;
+
+  // ---- First-party value noise + 2D curl (divergence-free) -----------------
+  function hash(x, y) {
+    var n = Math.sin(x * 127.1 + y * 311.7) * 43758.5453;
+    return n - Math.floor(n);
+  }
+  function vnoise(x, y) {
+    var xi = Math.floor(x), yi = Math.floor(y);
+    var xf = x - xi, yf = y - yi;
+    var u = xf * xf * (3 - 2 * xf), v = yf * yf * (3 - 2 * yf);
+    var a = hash(xi, yi), b = hash(xi + 1, yi), c = hash(xi, yi + 1), d = hash(xi + 1, yi + 1);
+    return a * (1 - u) * (1 - v) + b * u * (1 - v) + c * (1 - u) * v + d * u * v;
+  }
+  // curl of a scalar noise potential => (∂n/∂y, −∂n/∂x): swirls, never clumps.
+  var NS = 0.0016; // spatial scale of the field
+  function curl(x, y, t, out) {
+    var e = 1.0;
+    var n1 = vnoise(x * NS, (y + e) * NS + t) - vnoise(x * NS, (y - e) * NS + t);
+    var n2 = vnoise((x + e) * NS, y * NS + t) - vnoise((x - e) * NS, y * NS + t);
+    out[0] = n1; out[1] = -n2;
   }
 
-  function starBudget() {
-    // Scale with area, but stay bounded so the loop never pegs the CPU
-    // (AC-A10). ~1 star per 12k CSS px^2, hard-capped.
-    return Math.max(40, Math.min(150, Math.round((W * H) / 12000)));
-  }
+  // ---- Figures: the site's own sigils, rasterised to target points ---------
+  // Polyline segments in a 50-unit box (the original inline-SVG sigil coords).
+  var SIGILS = {
+    fire: [[[25, 5], [25, 45]], [[15, 15], [35, 35]], [[15, 35], [35, 15]]],
+    water: [[[15, 25], [35, 25]], [[15, 15], [35, 15]], [[15, 35], [35, 35]]],
+    air: [[[25, 5], [25, 45]], [[15, 15], [35, 15]]],
+    earth: [[[15, 15], [35, 15]], [[25, 15], [25, 35]], [[15, 35], [35, 35]]],
+    ansuz: [[[20, 8], [31, 8], [19, 44]]],
+    laguz: [[[25, 8], [25, 44], [37, 20]]]
+  };
 
-  function seedStars() {
-    var rand = makeRng(0x5eed);          // reset each seeding -> stable layout
-    var n = starBudget();
-    stars = [];
-    for (var i = 0; i < n; i++) {
-      stars.push({
-        x: rand() * W,
-        y: rand() * H,
-        z: 0.4 + rand() * 0.9,           // depth: size + parallax weight + speed
-        r: 0.5 + rand() * 1.4,           // radius
-        vx: (rand() - 0.5) * 0.06,       // slow ambient drift (CSS px / frame)
-        vy: (rand() - 0.5) * 0.06,
-        tw: rand() * Math.PI * 2,         // twinkle phase
-        tws: 0.6 + rand() * 1.2,          // twinkle speed
-        base: 0.35 + rand() * 0.5,        // base opacity
-        tint: STAR_TINTS[(rand() * STAR_TINTS.length) | 0]
-      });
-    }
-  }
-
-  function renderNebula() {
-    // Pre-render the soft clouds ONCE per resize into an offscreen buffer with
-    // a margin so the whole-scene parallax never exposes an edge. Each frame
-    // then only blits this (cheap) instead of rebuilding gradients.
-    var margin = 24;
-    nebula.width = (W + margin * 2) * dpr;
-    nebula.height = (H + margin * 2) * dpr;
-    nctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    nctx.clearRect(0, 0, W + margin * 2, H + margin * 2);
-    for (var i = 0; i < NEBULA_BLOBS.length; i++) {
-      var b = NEBULA_BLOBS[i];
-      var cx = margin + b.xr * W;
-      var cy = margin + b.yr * H;
-      var rad = Math.max(W, H) * 0.45;
-      var g = nctx.createRadialGradient(cx, cy, 0, cx, cy, rad);
-      g.addColorStop(0, b.col + b.a + ')');
-      g.addColorStop(1, b.col + '0)');
-      nctx.fillStyle = g;
-      nctx.fillRect(0, 0, W + margin * 2, H + margin * 2);
-    }
-  }
-
-  function resize() {
-    W = window.innerWidth;
-    H = window.innerHeight;
-    dpr = Math.min(window.devicePixelRatio || 1, 2);
-    canvas.width = W * dpr;
-    canvas.height = H * dpr;
-    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    seedStars();
-    renderNebula();
-  }
-
-  // ---- Rendering ----------------------------------------------------------
-  function drawFrame(dt, animate) {
-    ctx.clearRect(0, 0, W, H);
-
-    // Ease the scene parallax toward the pointer (whisper only: <=6px).
-    var targetPx = 0, targetPy = 0;
-    if (pointer.active && animate) {
-      targetPx = ((pointer.x / W) - 0.5) * -12; // opposite the cursor, subtle
-      targetPy = ((pointer.y / H) - 0.5) * -12;
-    }
-    scene.px += (targetPx - scene.px) * 0.06;
-    scene.py += (targetPy - scene.py) * 0.06;
-
-    // Nebula (blitted, parallax-shifted). Margin was 24px; center the buffer.
-    ctx.drawImage(nebula, -24 + scene.px * 0.6, -24 + scene.py * 0.6, W + 48, H + 48);
-
-    // Stars
-    var influence = 150;         // pointer influence radius
-    var linkDist = 116;          // constellation link distance
-    var near = [];               // stars inside the pointer's influence
-    for (var i = 0; i < stars.length; i++) {
-      var s = stars[i];
-      if (animate) {
-        s.x += s.vx * s.z * dt;
-        s.y += s.vy * s.z * dt;
-        s.tw += 0.02 * s.tws * dt;
-        // wrap
-        if (s.x < -4) s.x = W + 4; else if (s.x > W + 4) s.x = -4;
-        if (s.y < -4) s.y = H + 4; else if (s.y > H + 4) s.y = -4;
-      }
-
-      var dx = 0, dy = 0, drawX = s.x + scene.px * s.z, drawY = s.y + scene.py * s.z;
-      var glow = 0;
-      if (pointer.active) {
-        dx = pointer.x - s.x;
-        dy = pointer.y - s.y;
-        var d2 = dx * dx + dy * dy;
-        if (d2 < influence * influence) {
-          var d = Math.sqrt(d2) || 1;
-          var pull = (1 - d / influence);
-          glow = pull;
-          if (animate) {
-            // LOCAL attraction: nudge toward the cursor (short distance, small
-            // area -> low vestibular risk).
-            drawX += (dx / d) * pull * 6;
-            drawY += (dy / d) * pull * 6;
-          } else {
-            drawX += (dx / d) * pull * 6; // static frame still shows the halo shape
-          }
-          near.push({ s: s, x: drawX, y: drawY });
-        }
-      }
-
-      var tw = animate ? (0.72 + 0.28 * Math.sin(s.tw)) : 0.85;
-      var alpha = Math.min(1, s.base * tw + glow * 0.5);
+  function strokeSegments(ctx, segs, s, lw) {
+    var k = s / 50;
+    ctx.lineWidth = lw; ctx.lineCap = 'round'; ctx.lineJoin = 'round';
+    ctx.strokeStyle = '#fff';
+    for (var i = 0; i < segs.length; i++) {
+      var seg = segs[i];
       ctx.beginPath();
-      ctx.arc(drawX, drawY, s.r + glow * 0.9, 0, Math.PI * 2);
-      ctx.fillStyle = s.tint + alpha.toFixed(3) + ')';
+      for (var j = 0; j < seg.length; j++) {
+        var px = seg[j][0] * k, py = seg[j][1] * k;
+        if (j === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+      }
+      ctx.stroke();
+    }
+  }
+
+  // The default figure: the alchemy circle itself, re-expressed as dust.
+  function drawAlchemyCircle(ctx, s) {
+    var k = s / 50, c = 25 * k, lw = Math.max(2, s * 0.014);
+    ctx.strokeStyle = '#fff'; ctx.lineWidth = lw; ctx.lineCap = 'round';
+    ctx.beginPath(); ctx.arc(c, c, 21 * k, 0, Math.PI * 2); ctx.stroke();
+    ctx.beginPath(); ctx.arc(c, c, 13 * k, 0, Math.PI * 2); ctx.stroke();
+    // inner cross
+    strokeSegments(ctx, [[[25, 9], [25, 41]], [[9, 25], [41, 25]]], s, lw);
+    // four cardinal nodes on the outer ring
+    var r = 21 * k;
+    for (var a = 0; a < 4; a++) {
+      var ang = a * Math.PI / 2;
+      ctx.beginPath();
+      ctx.arc(c + Math.cos(ang) * r, c + Math.sin(ang) * r, lw * 1.1, 0, Math.PI * 2);
       ctx.fill();
     }
+  }
 
-    // Constellation: link near-pointer stars to each other, and to the cursor.
-    // Only the small `near` subset is considered, so this stays cheap.
-    if (near.length > 1) {
-      for (var a = 0; a < near.length; a++) {
-        for (var b2 = a + 1; b2 < near.length; b2++) {
-          var lx = near[a].x - near[b2].x, ly = near[a].y - near[b2].y;
-          var ld = Math.sqrt(lx * lx + ly * ly);
-          if (ld < linkDist) {
-            var la = (1 - ld / linkDist) * 0.5;
-            ctx.beginPath();
-            ctx.moveTo(near[a].x, near[a].y);
-            ctx.lineTo(near[b2].x, near[b2].y);
-            ctx.strokeStyle = 'rgba(205,180,219,' + la.toFixed(3) + ')';
-            ctx.lineWidth = 0.6;
-            ctx.stroke();
+  function drawSigil(name) {
+    return function (ctx, s) { strokeSegments(ctx, SIGILS[name], s, Math.max(2, s * 0.02)); };
+  }
+
+  // Ordered figure set — starts on the alchemy circle (the brand centrepiece,
+  // now formed from living dust), clicks cycle through the elements + runes.
+  var FIGURE_DEFS = [
+    drawAlchemyCircle,
+    drawSigil('fire'), drawSigil('water'), drawSigil('air'),
+    drawSigil('earth'), drawSigil('ansuz'), drawSigil('laguz')
+  ];
+  var figures = [];      // each: array of {x,y} target points (figure-local, centred)
+  var figureIndex = 0;
+
+  function rasterizeFigures() {
+    figures = [];
+    var s = figureSize;
+    var pad = Math.max(8, s * 0.12);
+    var dim = Math.ceil(s + pad * 2);
+    var oc = document.createElement('canvas');
+    oc.width = dim; oc.height = dim;
+    var octx = oc.getContext('2d');
+    for (var f = 0; f < FIGURE_DEFS.length; f++) {
+      octx.clearRect(0, 0, dim, dim);
+      octx.save();
+      octx.translate(pad, pad);
+      FIGURE_DEFS[f](octx, s);
+      octx.restore();
+      var img = octx.getImageData(0, 0, dim, dim).data;
+      var pts = [];
+      var stride = 2;
+      for (var y = 0; y < dim; y += stride) {
+        for (var x = 0; x < dim; x += stride) {
+          if (img[(y * dim + x) * 4 + 3] > 80) {
+            pts.push({ x: x - dim / 2, y: y - dim / 2 }); // centred on figure
           }
         }
       }
+      figures.push(pts.length ? pts : [{ x: 0, y: 0 }]);
     }
   }
 
-  // ---- Loop + FPS ---------------------------------------------------------
-  var lastTs = 0, frames = 0, fpsAccum = 0, fps = 0;
+  // ---- Particles -----------------------------------------------------------
+  var particles = [];
+  function particleBudget() {
+    return Math.max(1300, Math.min(2600, Math.round((W * H) / 620)));
+  }
+  function assignTargets(idx) {
+    var pts = figures[idx];
+    var m = pts.length, n = particles.length;
+    for (var i = 0; i < n; i++) {
+      // spread N particles EVENLY across ALL M target points (never just the
+      // first N), so the whole figure is covered whether N<M or N>M.
+      var t = pts[Math.floor(i * m / n) % m];
+      particles[i].tx = figureCX + t.x + (hash(i, idx) - 0.5) * 2.5;
+      particles[i].ty = figureCY + t.y + (hash(i + 7, idx) - 0.5) * 2.5;
+    }
+  }
+  function seedParticles() {
+    var n = particleBudget();
+    particles = [];
+    for (var i = 0; i < n; i++) {
+      // scattered in a disc around the figure — the void it condenses from
+      var ang = hash(i, 1) * Math.PI * 2;
+      var rad = (0.4 + hash(i, 2) * 1.3) * figureSize;
+      particles.push({
+        x: figureCX + Math.cos(ang) * rad,
+        y: figureCY + Math.sin(ang) * rad,
+        vx: 0, vy: 0, tx: figureCX, ty: figureCY,
+        sz: hash(i, 3) < 0.15 ? 2 : 1,     // a few brighter grains
+        seed: hash(i, 4)
+      });
+    }
+    assignTargets(figureIndex);
+  }
 
+  // ---- Phase machine -------------------------------------------------------
+  var phase = 'coagula';        // 'coagula' | 'rest' | 'solve'
+  var phaseT = 0;               // ms into the current phase
+  var COAG_MS = 3200, SOLVE_MS = 1500;
+  var warm = 1;                 // 0 = dissolved violet, 1 = coagulated gold
+  var pointer = { x: -9999, y: -9999, active: false };
+
+  function startSolve() {
+    if (phase === 'solve') return;
+    phase = 'solve'; phaseT = 0;
+  }
+
+  function stepParticles(dt, ms, animate) {
+    phaseT += ms;
+    var targetWarm = phase === 'solve' ? 0.12 : 1;
+    warm += (targetWarm - warm) * Math.min(1, 0.06 * dt);
+
+    var EASE = phase === 'coagula' ? 0.06 : 0.028;
+    var DAMP = phase === 'solve' ? 0.94 : 0.84;
+    var CURL = 2.6;
+    var R = 128, RF = 1.05;
+    var out = [0, 0];
+    var t = phaseT * 0.00006;
+
+    for (var i = 0; i < particles.length; i++) {
+      var p = particles[i];
+      if (phase === 'solve' && animate) {
+        curl(p.x, p.y, t, out);
+        p.vx += out[0] * CURL; p.vy += out[1] * CURL;
+      } else {
+        p.vx += (p.tx - p.x) * EASE; p.vy += (p.ty - p.y) * EASE;
+      }
+      // Pointer = the alchemist's hand. It NEVER fights coagulation (so the
+      // figure always forms cleanly); it STIRS the dissolved matter during
+      // solve and SCATTERS the settled dust at rest (which then re-gathers) —
+      // a material response, not a diagram.
+      if (pointer.active && animate && phase !== 'coagula') {
+        var dx = p.x - pointer.x, dy = p.y - pointer.y;
+        var d2 = dx * dx + dy * dy;
+        if (d2 < R * R) {
+          var d = Math.sqrt(d2) || 1, force = (1 - d / R) * RF;
+          if (phase === 'solve') {                       // swirl
+            p.vx += (-dy / d) * force + (dx / d) * force * 0.25;
+            p.vy += (dx / d) * force + (dy / d) * force * 0.25;
+          } else {                                        // scatter, then re-gather
+            p.vx += (dx / d) * force; p.vy += (dy / d) * force;
+          }
+        }
+      }
+      p.vx *= DAMP; p.vy *= DAMP;
+      p.x += p.vx * dt; p.y += p.vy * dt;
+    }
+
+    if (phase === 'coagula' && phaseT >= COAG_MS) { phase = 'rest'; phaseT = 0; }
+    else if (phase === 'solve' && phaseT >= SOLVE_MS) {
+      figureIndex = (figureIndex + 1) % figures.length;
+      assignTargets(figureIndex);
+      phase = 'coagula'; phaseT = 0;
+    }
+  }
+
+  // ---- Rendering -----------------------------------------------------------
+  function drawGround() {
+    // nigredo→violet slab, gold aurum glows massed to the LEFT (behind the
+    // figure, away from the headline zone), then a Bayer-8 ordered dither for
+    // 16-bit grain. Drawn ONCE per resize — static, zero vestibular cost.
+    var g = bctx.createLinearGradient(0, 0, W, H);
+    g.addColorStop(0, 'rgb(19,16,30)');   // nigredo — dark so the aurum dust pops
+    g.addColorStop(1, 'rgb(27,22,42)');
+    bctx.fillStyle = g; bctx.fillRect(0, 0, W, H);
+
+    function glow(cx, cy, rad, col, a) {
+      var rg = bctx.createRadialGradient(cx, cy, 0, cx, cy, rad);
+      rg.addColorStop(0, 'rgba(' + col.join(',') + ',' + a + ')');
+      rg.addColorStop(1, 'rgba(' + col.join(',') + ',0)');
+      bctx.fillStyle = rg; bctx.fillRect(0, 0, W, H);
+    }
+    glow(figureCX, figureCY, figureSize * 1.45, [96, 60, 156], 0.34);           // contained violet aura
+    glow(figureCX + figureSize * 0.05, figureCY, figureSize * 0.72, AURUM, 0.10); // warm gold heart under the figure
+    glow(W * 0.86, H * 0.12, Math.max(W, H) * 0.5, [66, 60, 138], 0.07);        // faint cool corner
+
+    ditherGround();
+  }
+
+  var BAYER8 = [
+    0, 32, 8, 40, 2, 34, 10, 42, 48, 16, 56, 24, 50, 18, 58, 26,
+    12, 44, 4, 36, 14, 46, 6, 38, 60, 28, 52, 20, 62, 30, 54, 22,
+    3, 35, 11, 43, 1, 33, 9, 41, 51, 19, 59, 27, 49, 17, 57, 25,
+    15, 47, 7, 39, 13, 45, 5, 37, 63, 31, 55, 23, 61, 29, 53, 21
+  ];
+  function ditherGround() {
+    // Ordered Bayer dither for a 16-bit-era grain — but broken up with a small
+    // per-pixel hash so it reads as GRAIN, not a regular screen-door mesh, and
+    // kept subtle (L high) so it's a texture you feel, not a pattern you see.
+    var L = 11, w = bg.width, h = bg.height;
+    var img = bctx.getImageData(0, 0, w, h), d = img.data;
+    var q = (L - 1);
+    for (var y = 0; y < h; y++) {
+      var row = (y & 7) * 8;
+      for (var x = 0; x < w; x++) {
+        var thr = (BAYER8[row + (x & 7)] + 0.5) / 64 - 0.5;
+        thr += (hash(x, y) - 0.5) * 0.55; // grain, not weave
+        var o = (y * w + x) * 4;
+        for (var c = 0; c < 3; c++) {
+          var v = d[o + c] / 255 * q + thr;
+          v = Math.round(v < 0 ? 0 : v > q ? q : v);
+          d[o + c] = (v / q) * 255;
+        }
+      }
+    }
+    bctx.putImageData(img, 0, 0);
+  }
+
+  function drawStill() {
+    // reduced-motion / paused substitute: the coagulated figure as a long
+    // exposure — particles at their targets, no motion, no loop.
+    fctx.clearRect(0, 0, W, H);
+    fctx.globalCompositeOperation = 'lighter';
+    var col = 'rgba(' + AURUM.join(',') + ',';
+    for (var i = 0; i < particles.length; i++) {
+      var p = particles[i];
+      fctx.fillStyle = col + (0.62 + p.seed * 0.45).toFixed(3) + ')';
+      fctx.fillRect(p.tx, p.ty, p.sz + 0.5, p.sz + 0.5);
+    }
+    fctx.globalCompositeOperation = 'source-over';
+    setFps(null);
+  }
+
+  function mix(a, b, t) { return [a[0] + (b[0] - a[0]) * t, a[1] + (b[1] - a[1]) * t, a[2] + (b[2] - a[2]) * t]; }
+
+  function drawDust() {
+    // trail fade (destination-out keeps the layer transparent over the ground)
+    fctx.globalCompositeOperation = 'destination-out';
+    fctx.fillStyle = 'rgba(0,0,0,' + (phase === 'solve' ? 0.10 : 0.16) + ')';
+    fctx.fillRect(0, 0, W, H);
+
+    fctx.globalCompositeOperation = 'lighter';
+    var c = mix(LAVENDER, AURUM, warm);
+    var breath = phase === 'rest' ? (0.82 + 0.18 * Math.sin(phaseT * 0.0016)) : 1;
+    var head = 'rgb(' + (c[0] | 0) + ',' + (c[1] | 0) + ',' + (c[2] | 0) + ')';
+    fctx.fillStyle = head;
+    for (var i = 0; i < particles.length; i++) {
+      var p = particles[i];
+      fctx.globalAlpha = (0.35 + p.seed * 0.5) * breath;
+      fctx.fillRect(p.x, p.y, p.sz, p.sz);
+    }
+    fctx.globalAlpha = 1;
+    fctx.globalCompositeOperation = 'source-over';
+  }
+
+  // ---- Loop + FPS ----------------------------------------------------------
+  var rafId = null, running = false, lastTs = 0, frames = 0, fpsAccum = 0;
   function loop(ts) {
     if (!running) return;
-    var dt = lastTs ? Math.min((ts - lastTs) / 16.667, 3) : 1; // frames elapsed, clamped
+    var ms = lastTs ? Math.min(ts - lastTs, 60) : 16.7;
+    var dt = ms / 16.7;
     lastTs = ts;
-
-    drawFrame(dt, true);
-
-    // FPS readout, refreshed ~twice a second.
-    frames++;
-    fpsAccum += ts - (loop._prev || ts);
-    loop._prev = ts;
-    if (fpsAccum >= 500) {
-      fps = Math.round((frames * 1000) / fpsAccum);
-      frames = 0; fpsAccum = 0;
-      setFps(fps);
-    }
-
+    stepParticles(dt, ms, true);
+    drawDust();
+    frames++; fpsAccum += ms;
+    if (fpsAccum >= 500) { setFps(Math.round(frames * 1000 / fpsAccum)); frames = 0; fpsAccum = 0; }
     rafId = window.requestAnimationFrame(loop);
   }
-
   function start() {
     if (running) return;
-    running = true;
-    lastTs = 0; loop._prev = 0; frames = 0; fpsAccum = 0;
+    running = true; lastTs = 0; frames = 0; fpsAccum = 0;
     rafId = window.requestAnimationFrame(loop);
   }
-  function stop() {
-    running = false;
-    if (rafId) { window.cancelAnimationFrame(rafId); rafId = null; }
-    setFps(null);
-  }
-  function staticFrame() {
-    // One premium still frame -- no loop, no motion.
-    drawFrame(1, false);
-    setFps(null);
-  }
+  function stop() { running = false; if (rafId) { window.cancelAnimationFrame(rafId); rafId = null; } setFps(null); }
 
-  // ---- HUD (FPS readout + the 2.2.2 pause control) ------------------------
+  // ---- HUD (FPS readout + the 2.2.2 pause control) -------------------------
   var hud = document.createElement('div');
   hud.className = 'observatory-hud';
-
   var toggle = document.createElement('button');
-  toggle.type = 'button';
-  toggle.className = 'observatory-hud__toggle';
+  toggle.type = 'button'; toggle.className = 'observatory-hud__toggle';
   var icon = document.createElement('span');
-  icon.className = 'observatory-hud__icon';
-  icon.setAttribute('aria-hidden', 'true');
+  icon.className = 'observatory-hud__icon'; icon.setAttribute('aria-hidden', 'true');
   toggle.appendChild(icon);
-
   var fpsEl = document.createElement('span');
-  fpsEl.className = 'observatory-hud__fps';
-  fpsEl.setAttribute('aria-hidden', 'true');
+  fpsEl.className = 'observatory-hud__fps'; fpsEl.setAttribute('aria-hidden', 'true');
   fpsEl.textContent = 'FPS —';
-
-  hud.appendChild(toggle);
-  hud.appendChild(fpsEl);
+  hud.appendChild(toggle); hud.appendChild(fpsEl);
   hero.appendChild(hud);
 
-  function setFps(v) {
-    fpsEl.textContent = 'FPS ' + (v == null ? '—' : v);
-  }
-
+  function setFps(v) { fpsEl.textContent = 'FPS ' + (v == null ? '—' : v); }
   function reflectToggle(on) {
-    // aria-pressed = "is motion paused". on === animating.
     toggle.setAttribute('aria-pressed', on ? 'false' : 'true');
-    toggle.setAttribute('aria-label', on ? 'Pause ambient motion' : 'Play ambient motion');
-    toggle.title = on ? 'Pause the observatory' : 'Wake the observatory';
+    toggle.setAttribute('aria-label', on ? 'Pause the transmutation' : 'Resume the transmutation');
+    toggle.title = on ? 'Pause the transmutation' : 'Resume the transmutation';
     hud.classList.toggle('is-paused', !on);
   }
-
-  // Apply the current policy: run the loop or hold a static frame.
   function apply() {
     var on = motionEnabled();
     reflectToggle(on);
-    if (on) start(); else { stop(); staticFrame(); }
+    if (on) { phase = 'coagula'; phaseT = 0; warm = 0.2; start(); }
+    else { stop(); drawStill(); }
   }
-
   toggle.addEventListener('click', function () {
     var on = motionEnabled();
-    savePref(on ? 'off' : 'on'); // explicit choice overrides the OS default
+    savePref(on ? 'off' : 'on');
     apply();
   });
 
-  // ---- Pointer, resize, visibility ----------------------------------------
+  // ---- Input, resize, visibility ------------------------------------------
   function onPointer(e) {
     var t = e.touches ? e.touches[0] : e;
     if (!t) return;
-    pointer.x = t.clientX;
-    pointer.y = t.clientY;
-    pointer.active = true;
-    // A paused/static observatory still reveals the constellation on hover --
-    // it's pointer-driven (2.3.3), not auto-play, so it stays available even
-    // when the ambient loop is stopped.
-    if (!running) staticFrame();
+    pointer.x = t.clientX; pointer.y = t.clientY; pointer.active = true;
   }
-  function clearPointer() {
-    pointer.active = false;
-    if (!running) staticFrame();
-  }
+  function clearPointer() { pointer.active = false; }
   window.addEventListener('mousemove', onPointer, { passive: true });
   window.addEventListener('touchmove', onPointer, { passive: true });
   window.addEventListener('mouseleave', clearPointer);
   window.addEventListener('touchend', clearPointer);
+  // click anywhere on the hero backdrop triggers a transmutation to the next
+  // figure (ignored on interactive elements so links/buttons still work).
+  hero.addEventListener('click', function (e) {
+    if (e.target.closest('a, button')) return;
+    if (running) startSolve();
+  });
 
-  var resizeTimer;
+  function sizeFor() {
+    W = window.innerWidth; H = window.innerHeight;
+    dpr = Math.min(window.devicePixelRatio || 1, 2);
+    // figure: left-of-centre on wide screens, upper-centre on narrow ones
+    if (W >= 900) { figureCX = W * 0.32; figureCY = H * 0.52; figureSize = Math.min(460, H * 0.6, W * 0.44); }
+    else { figureCX = W * 0.5; figureCY = H * 0.26; figureSize = Math.min(228, W * 0.6, H * 0.3); }
+    [bg, fg].forEach(function (cv) {
+      cv.width = W * dpr; cv.height = H * dpr;
+      cv.getContext('2d').setTransform(dpr, 0, 0, dpr, 0, 0);
+    });
+  }
+  function rebuild(keepPhase) {
+    sizeFor();
+    rasterizeFigures();
+    if (!particles.length) seedParticles(); else assignTargets(figureIndex);
+    drawGround();
+    if (running) { fctx.clearRect(0, 0, W, H); } else drawStill();
+  }
+  var rt;
   window.addEventListener('resize', function () {
-    clearTimeout(resizeTimer);
-    resizeTimer = setTimeout(function () {
-      resize();
-      if (running) { /* loop keeps going */ } else { staticFrame(); }
-    }, 200);
+    clearTimeout(rt); rt = setTimeout(function () { rebuild(true); }, 200);
   });
-
-  // Never burn cycles on a hidden tab (AC-A10).
   document.addEventListener('visibilitychange', function () {
-    if (document.hidden) {
-      if (running) stop();
-    } else {
-      if (motionEnabled()) start();
-    }
+    if (document.hidden) { if (running) stop(); }
+    else if (motionEnabled() && !running) { start(); }
   });
-
-  // React live to an OS reduced-motion change (only matters when the visitor
-  // hasn't made an explicit choice).
   var onReduceChange = function () { if (storedPref() == null) apply(); };
   if (reduceQuery.addEventListener) reduceQuery.addEventListener('change', onReduceChange);
   else if (reduceQuery.addListener) reduceQuery.addListener(onReduceChange);
 
-  // ---- Console homage (earendil-style dev wink) ---------------------------
-  function consoleSigil() {
-    var sigil = [
-      '',
-      '        .  *  .   ·   *   .  ·  *  .',
-      '     ·   ╭─────────────────────╮   *',
-      '   *     │   ☿   THE  ATELIER   │  ·',
-      '     .   │   ⚗   OBSERVATORY    │    .',
-      '   ·     ╰─────────────────────╯  *  .',
-      '        *   .   ·    *   .   ·   *',
-      ''
-    ].join('\n');
-    try {
-      console.log('%c' + sigil, 'color:#cdb4db; font-family:monospace; line-height:1.15;');
-      console.log(
-        '%cSolve et Coagula.%c  You found the console — a true alchemist always looks beneath the surface.\n' +
-        'The stars remember those who look up. Some old spells still work on keyboards: %c↑ ↑ ↓ ↓ ← → ← → B A%c',
-        'color:#e6a553; font-weight:bold; font-family:monospace;',
-        'color:#b9c9e6; font-family:monospace;',
-        'color:#f8d1e0; font-family:monospace;',
-        'color:#b9c9e6; font-family:monospace;'
-      );
-    } catch (e) { /* no console: fine */ }
-  }
+  // ---- Console homage ------------------------------------------------------
+  try {
+    console.log('%c  ☿ ⚗  SOLVE ET COAGULA  ⚗ ☿',
+      'color:#e6a553;font-family:monospace;font-weight:bold;');
+    console.log('%cDissolve, and bind anew. You found the console — every alchemist looks beneath the surface.\n' +
+      'Old spells still work on keyboards: %c↑ ↑ ↓ ↓ ← → ← → B A',
+      'color:#b9c9e6;font-family:monospace;', 'color:#f8d1e0;font-family:monospace;');
+  } catch (e) {}
 
-  // ---- Boot ---------------------------------------------------------------
-  resize();
-  // Fade the sky in (opacity is vestibular-safe for everyone).
-  requestAnimationFrame(function () { canvas.classList.add('is-lit'); });
-  apply();
-  consoleSigil();
-
-  // Expose a tiny hook so home.js's Konami payoff can ask the sky to flare
-  // without either file reaching into the other's internals.
+  // ---- Public API for home.js's Konami payoff ------------------------------
   window.Observatory = {
+    transmute: function () { if (running) startSolve(); },
     flare: function () {
-      if (!hero) return;
       hero.classList.add('is-transmuting');
       window.setTimeout(function () { hero.classList.remove('is-transmuting'); }, 2600);
+      if (running) { figureIndex = 0; startSolve(); } // grand work returns to the circle
     },
     isRunning: function () { return running; }
   };
+
+  // ---- Boot ----------------------------------------------------------------
+  rebuild(false);
+  window.requestAnimationFrame(function () { bg.classList.add('is-lit'); fg.classList.add('is-lit'); });
+  apply();
 })();

--- a/index.html
+++ b/index.html
@@ -3,68 +3,14 @@ layout: default
 ---
 
 <div class="alchemist-hero">
-  <div class="alchemy-circle">
-    <!-- Central circle -->
-    <div class="alchemy-circle__inner"></div>
-
-    <!-- Orbital rings -->
-    <div class="alchemy-circle__ring alchemy-circle__ring--1"></div>
-    <div class="alchemy-circle__ring alchemy-circle__ring--2"></div>
-    <div class="alchemy-circle__ring alchemy-circle__ring--3"></div>
-
-    <!-- Add a subtle glow -->
-    <div class="alchemy-circle__glow"></div>
-
-    <!-- Alchemical symbols -->
-    <div class="alchemy-symbol alchemy-symbol--fire" title="Fire (Creativity)" style="--symbol-color: #FF5E5B;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M25,5 L25,45 M15,15 L35,35 M15,35 L35,15" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </div>
-    <div class="alchemy-symbol alchemy-symbol--water" title="Water (Adaptability)" style="--symbol-color: #5B8CFF;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M15,25 L35,25 M15,15 L35,15 M15,35 L35,35" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </div>
-    <div class="alchemy-symbol alchemy-symbol--air" title="Air (Intellect)" style="--symbol-color: #FFDE59;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M25,5 L25,45 M15,15 L35,15" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </div>
-    <div class="alchemy-symbol alchemy-symbol--earth" title="Earth (Stability)" style="--symbol-color: #7ED957;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M15,15 L35,15 M25,15 L25,35 M15,35 L35,35" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </div>
-    <div class="alchemy-symbol alchemy-symbol--quintessence" title="Quintessence (Excellence)" style="--symbol-color: #C77DFF;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <circle cx="25" cy="25" r="15" fill="none" stroke="currentColor" stroke-width="2" />
-        <path d="M25,10 L25,40 M10,25 L40,25" stroke="currentColor" stroke-width="2" />
-      </svg>
-    </div>
-
-    <!-- Nordic runes -->
-    <div class="rune rune--ansuz" title="Ansuz (Communication)" style="--symbol-color: #FF9E7D;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M20,10 L30,10 L20,40" stroke="currentColor" stroke-width="2" fill="none" />
-      </svg>
-    </div>
-    <div class="rune rune--kenaz" title="Kenaz (Knowledge)" style="--symbol-color: #FF7D7D;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M20,10 L30,25 L20,40" stroke="currentColor" stroke-width="2" fill="none" />
-      </svg>
-    </div>
-    <div class="rune rune--raidho" title="Raidho (Journey)" style="--symbol-color: #7DFFB9;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M20,10 L20,40 M20,10 L30,25 L20,25" stroke="currentColor" stroke-width="2" fill="none" />
-      </svg>
-    </div>
-    <div class="rune rune--laguz" title="Laguz (Flow)" style="--symbol-color: #7DCAFF;">
-      <svg viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
-        <path d="M25,10 L25,40 L35,20" stroke="currentColor" stroke-width="2" fill="none" />
-      </svg>
-    </div>
-  </div>
+  <!-- Change `hero-transmutation`: the alchemy circle + element sigils + Nordic
+       runes are no longer static DOM/SVG. They are rasterised inside
+       observatory.js and rendered as living dust — the particle field
+       coagulates onto their geometry and dissolves back ("Solve et Coagula").
+       The two canvases (dithered prima-materia ground + trailed dust) and the
+       HUD are created by observatory.js as a progressive-enhancement layer, so
+       with JavaScript off the hero degrades to its dithered gradient with no
+       empty canvas. -->
 
   <div class="hero__content">
     <h1 class="hero__title fade-in">Henrique A. Lavezzo</h1>
@@ -99,9 +45,5 @@ layout: default
      (footer). The sitewide footer still renders on this page (AC-020), so the
      disclaimer + secondary nav are not lost. -->
 
-<!-- The Observatory (canvas nebula/stardust/constellation) and its HUD (FPS readout +
-     the WCAG 2.2.2 motion pause control -- research-ui-a11y.md §3.2) are created by
-     observatory.js as a progressive-enhancement layer: with JavaScript off, the hero
-     degrades cleanly to its gradient + finite CSS animations, no empty canvas. -->
 <script src="{{ "/assets/js/observatory.js" | relative_url }}" defer></script>
 <script src="{{ "/assets/js/home.js" | relative_url }}" defer></script>

--- a/index.html
+++ b/index.html
@@ -91,49 +91,17 @@ layout: default
   </div>
 </div>
 
-<!-- Reader-facing content below the hero (Story 2.1, AC-012). The homepage was a
-     hero-only landing (FINDING-008); this surfaces recent scrolls plus a curated
-     "best of" set via the `featured: true` front-matter flag, Larson's /featured
-     pattern, rather than hardcoding a post list. -->
-<section class="rpg-scrolls home-scrolls">
-  <div class="container">
-    {% include components/section-title.html icon="fas fa-scroll" title="Recent Scrolls" %}
+<!-- Change `home-atelier` / D1: the homepage is a single immersive viewport (the
+     "Alchemist's Observatory"). The former Recent Scrolls + Favorites sections lived
+     BELOW the fold on a scroll-locked page (`body.home { position: fixed; overflow:
+     hidden }`) -- in the DOM but unreachable. Rather than unlock the immersive hero,
+     those posts now live where they belong: the Notebook (main nav) and Start Here
+     (footer). The sitewide footer still renders on this page (AC-020), so the
+     disclaimer + secondary nav are not lost. -->
 
-    <div class="scrolls-collection">
-      {% for post in site.posts limit: 3 %}
-        {% include notebook/scroll-item.html post=post index=forloop.index %}
-      {% endfor %}
-    </div>
-
-    <p class="text-center mt-3">
-      <a href="{{ '/notebook/' | relative_url }}" class="scroll-link">
-        <span>Browse the full Notebook</span>
-        <i class="fas fa-arrow-right"></i>
-      </a>
-    </p>
-  </div>
-</section>
-
-{% assign featured_posts = site.posts | where: "featured", true %}
-{% if featured_posts.size > 0 %}
-<section class="rpg-scrolls home-scrolls home-scrolls--featured">
-  <div class="container">
-    {% include components/section-title.html icon="fas fa-award" title="Favorites from the Grimoire" %}
-
-    <div class="scrolls-collection">
-      {% for post in featured_posts %}
-        {% include notebook/scroll-item.html post=post index=forloop.index %}
-      {% endfor %}
-    </div>
-
-    <p class="text-center mt-3">
-      <a href="{{ '/start-here/' | relative_url }}" class="scroll-link">
-        <span>Not sure where to start? Try the Grimoire's Best Pages</span>
-        <i class="fas fa-arrow-right"></i>
-      </a>
-    </p>
-  </div>
-</section>
-{% endif %}
-
+<!-- The Observatory (canvas nebula/stardust/constellation) and its HUD (FPS readout +
+     the WCAG 2.2.2 motion pause control -- research-ui-a11y.md §3.2) are created by
+     observatory.js as a progressive-enhancement layer: with JavaScript off, the hero
+     degrades cleanly to its gradient + finite CSS animations, no empty canvas. -->
+<script src="{{ "/assets/js/observatory.js" | relative_url }}" defer></script>
 <script src="{{ "/assets/js/home.js" | relative_url }}" defer></script>


### PR DESCRIPTION
**Chained on #65** (base = `normalize/tokens`, so this PR shows only the homepage-rework diff on top of the normalization work).

Reworks the **main page** end-to-end, driven by inspiration (earendil.com) and a Fable deep-research report. Two tracked ESL changes, both **verified + drift_checked**.

## `home-atelier` — single-screen "Alchemist's Observatory" (commit `d2a9dc4`)
- Fixes a latent defect: the homepage locked scrolling yet had *Recent Scrolls* + *Favorites* stranded below the fold (in the DOM, unreachable). Those sections are removed; the posts stay reachable via nav → Notebook and the footer (sitewide disclaimer preserved, AC-020).
- Establishes the immersive single-screen hero + the dev-homage HUD (FPS readout + a real **WCAG 2.2.2 motion pause control**).

## `hero-transmutation` — "Solve et Coagula" particle transmutation (commit `7ca09fe`)
The owner's verdict on the first pass's constellation: *"almost no animation… looks like every canvas tutorial on the internet."* Fable's deep research (`.claude/rebrand/research-hero-backgrounds.md`, ~70 cited sources) confirmed proximity-line constellations are *the* canvas cliché, and recommended **Concept A (particle transmutation) over Concept B (dithered prima-materia field)**.

- **Constellation deleted at the root** — no proximity lines, starfield retired.
- `observatory.js` rewritten: first-party value/curl noise advects a few thousand motes that **dissolve** into divergence-free turbulence (*solve*) and **condense** onto alchemical figures rasterised from *the site's own sigils* (*coagula*). Click cycles the figures (alchemy circle → the five elements → runes); colour shifts violet↔gold across the stages.
- **The sigils are transformed, not kept** — the DOM alchemy-circle + static SVG glyphs are gone from markup; they're now formed from living dust.
- Ground: a static nigredo slab with a warm gold heart + a broken-up **Bayer dither** (grain, not a mesh) — 16-bit-era texture that reads as *authored*, escaping the "AI-slop purple-gradient" signature.
- Interaction is **material** (pointer stirs the dissolved matter / scatters resting dust that re-gathers), never diagrammatic; it never fights coagulation. The Konami spell triggers a grand-work gold flare + "Solve et Coagula" reveal.

## Accessibility (rigor preserved)
No-motion-first; one condense on load then a resting opacity breath; the HUD pause button is the 2.2.2 mechanism (`prefers-reduced-motion` alone does not discharge it); reduced-motion → a **static long-exposure** figure (never blank); pointer motion user-initiated (2.3.3); canvas `aria-hidden` + `pointer-events:none`; bounded particle budget + `visibilitychange` stop + seeded PRNG.

## Verification
- `npm run test:a11y-static` → 0 (manifest, token-usage, contrast, motion, dark-cascade, dead-class, clamp, text-spacing, a11y-page)
- `npm run test:axe` → **0 violations** across all pages, light + dark
- Playwright behaviour probe: load-condense / rest / click solve→coagula→next-sigil / reduced-motion still / Konami / mobile + desktop composition — 0 JS errors
- Also fixed a real BEM leak found along the way: `_about.scss`'s global `.hero__content { flex: 1 }` was stretching the home content (scoped-overridden via `body.home`).

Note: `scripts/baselines/` (gitignored visual-baseline PNGs) needs a local `test:visual --update` for the intentional redesign — not a CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)